### PR TITLE
Fix tab com for class instances which had wrong regex expression, unremo...

### DIFF
--- a/core/rint/src/TTabCom.cxx
+++ b/core/rint/src/TTabCom.cxx
@@ -2292,7 +2292,7 @@ void TTabCom::InitPatterns()
    SetPattern(kCXX_ScopeMember,
               "[_a-zA-Z][_a-zA-Z0-9]* *:: *[_a-zA-Z0-9]*$");
    SetPattern(kCXX_DirectMember,
-              "[_a-zA-Z][_a-zA-Z0-9()]* *. *[_a-zA-Z0-9()]*$");  //
+              "[_a-zA-Z][_a-zA-Z0-9()]* *\\. *[_a-zA-Z0-9()]*$");  //
 
    SetPattern(kCXX_IndirectMember,
               "[_a-zA-Z][_a-zA-Z0-9()]* *-> *[_a-zA-Z0-9()]*$");    // frodo


### PR DESCRIPTION
...ved '&' and no appearance of 'class' or 'const'.
