### PR TITLE
ROOT-6329

### DIFF
--- a/core/rint/inc/TTabCom.h
+++ b/core/rint/inc/TTabCom.h
@@ -74,7 +74,7 @@ public: // member functions
    const TSeqCollection* GetListOfCppDirectives();
    const TSeqCollection* GetListOfFilesInPath( const char path[] );
    const TSeqCollection* GetListOfEnvVars();
-   const TSeqCollection* GetListOfGlobalFunctions();
+   TCollection* GetListOfGlobalFunctions();
    const TSeqCollection* GetListOfGlobals();
    const TSeqCollection* GetListOfPragmas();
    const TSeqCollection* GetListOfSysIncFiles();

--- a/core/rint/src/TTabCom.cxx
+++ b/core/rint/src/TTabCom.cxx
@@ -359,7 +359,6 @@ void TTabCom::RehashFiles()
 void TTabCom::RehashGlobalFunctions()
 {
    // Reload global functions.
-   ClearGlobalFunctions();
    GetListOfGlobalFunctions();
 }
 
@@ -553,10 +552,10 @@ const TSeqCollection *TTabCom::GetListOfGlobals()
 }
 
 //______________________________________________________________________________
-const TSeqCollection *TTabCom::GetListOfGlobalFunctions()
+TCollection *TTabCom::GetListOfGlobalFunctions()
 {
    // Return the list of global functions.
-   return (TSeqCollection*) gROOT->GetListOfGlobalFunctions(true);
+   return gROOT->GetListOfGlobalFunctions(true);
 }
 
 //______________________________________________________________________________
@@ -2095,7 +2094,7 @@ Int_t TTabCom::Hook(char *buf, int *pLoc, std::ostream& out)
          const TSeqCollection *pC1 = GetListOfGlobals();
          if (pC1) pList->AddAll(pC1);
          //
-         const TSeqCollection *pC3 = GetListOfGlobalFunctions();
+         TCollection *pC3 = GetListOfGlobalFunctions();
          if (pC3) pList->AddAll(pC3);
 
          pos = Complete("[_a-zA-Z][_a-zA-Z0-9]*$", pList, "", out);


### PR DESCRIPTION
This is a temporary solution to get a reasonable subset of classes. Previously using ".class" and ".namespace" triggered deserialization. We have to implement getting the classes using decls. This uses gClassTable and mapFile. Another issue was with the implementation of TTabCom::GetListOfGlobalFunctions which did not iterate over the MethodInfos. Now using gROOT->GetListOfGlobalFunctions().
