### PR TITLE
TTabCom: Namespace treatment.

### DIFF
--- a/core/rint/inc/TTabCom.h
+++ b/core/rint/inc/TTabCom.h
@@ -214,7 +214,6 @@ private: // member functions
 
 private: // data members
    TSeqCollection* fpClasses;
-   TSeqCollection* fpNamespaces;  // Contains the names of namespaces registered in CINT.
    TSeqCollection* fpDirectives;
    TSeqCollection* fpEnvVars;
    TSeqCollection* fpFiles;


### PR DESCRIPTION
Do not treat namespaces diffrently than classes since we can not cluster them in advance as we do not use the expensive deserializing operation .namespace
