### PR TITLE
GetMissingDictionaries recursion for classes with dictionaries. (ROOT-62...

### DIFF
--- a/core/meta/inc/TClass.h
+++ b/core/meta/inc/TClass.h
@@ -258,9 +258,9 @@ private:
 protected:
    TVirtualStreamerInfo     *FindStreamerInfo(TObjArray* arr, UInt_t checksum) const;
    static THashTable        *GetClassTypedefHash();
-   void                      GetMissingDictionariesForBaseClasses(TCollection& result, bool recurse);
-   void                      GetMissingDictionariesForMembers(TCollection& result, bool recurse);
-   void                      GetMissingDictionariesWithRecursionCheck(TCollection& result, bool recurse);
+   void                      GetMissingDictionariesForBaseClasses(TCollection& result, TCollection& visited, bool recurse);
+   void                      GetMissingDictionariesForMembers(TCollection& result, TCollection& visited, bool recurse);
+   void                      GetMissingDictionariesWithRecursionCheck(TCollection& result, TCollection& visited, bool recurse);
 
 public:
    TClass();


### PR DESCRIPTION
...60)

The check for infinited recursion and caching of already checked classes was only made for classes without dictionaries and the case for classes with dictionaries was overlooked.
