### PR TITLE
Value extraction checking for deleted copy ctor (ROOT-6385).

### DIFF
--- a/interpreter/cling/lib/Interpreter/ValueExtractionSynthesizer.cpp
+++ b/interpreter/cling/lib/Interpreter/ValueExtractionSynthesizer.cpp
@@ -182,7 +182,9 @@ namespace {
       if(RD->hasTrivialCopyConstructor()) return true;
       // Lookup the copy canstructor and check its accessiblity.
       if (CXXConstructorDecl* CD = S->LookupCopyingConstructor(RD, QT.getCVRQualifiers())) {
-        if (CD ->getAccess() == clang::AccessSpecifier::AS_public) return true;
+        if (!CD->isDeleted() && CD ->getAccess() == clang::AccessSpecifier::AS_public) {
+          return true;
+        }
       }
       return false;
     }


### PR DESCRIPTION
During the value extraction the copy constructor availability check must ensure the copy ctor was not deleted.
