### PR TITLE
Root 7053

### DIFF
--- a/core/meta/src/TCling.cxx
+++ b/core/meta/src/TCling.cxx
@@ -1824,6 +1824,7 @@ Long_t TCling::ProcessLine(const char* line, EErrorCode* error/*=0*/)
    cling::Interpreter::CompilationResult compRes = cling::Interpreter::kSuccess;
    if (!strncmp(sLine.Data(), ".L", 2) || !strncmp(sLine.Data(), ".x", 2) ||
        !strncmp(sLine.Data(), ".X", 2)) {
+      cling::MetaProcessor::MaybeRedirectOutputRAII RAII(fMetaProcessor);
       // If there was a trailing "+", then CINT compiled the code above,
       // and we will need to strip the "+" before passing the line to cling.
       TString mod_line(sLine);

--- a/interpreter/cling/test/Prompt/hello.C
+++ b/interpreter/cling/test/Prompt/hello.C
@@ -1,4 +1,0 @@
-void hello() {
-   printf("Hello!");
-   return;
-}

--- a/interpreter/cling/test/Prompt/hello.C
+++ b/interpreter/cling/test/Prompt/hello.C
@@ -1,0 +1,4 @@
+void hello() {
+   printf("Hello!");
+   return;
+}


### PR DESCRIPTION
Fixed Root 7053 Jira bug.  Added MetaProcessor::MaybeRedirectOutputRAII function in TCling.cxx to handle .x command redirection in the root prompt. 