### PR TITLE
ROOT-7094 Bug fix for double tab completion crash.

### DIFF
--- a/core/rint/src/TTabCom.cxx
+++ b/core/rint/src/TTabCom.cxx
@@ -2297,12 +2297,10 @@ TClass *TTabCom::MakeClassFromVarName(const char varName[],
 
          // Check if it's a member
          TDataMember *dmptr = 0; //pclass->GetDataMember(memberName.Data());
-         TList  *dlist = pclass->GetListOfDataMembers();
          TIter   next(pclass->GetListOfAllPublicDataMembers());
          while ((dmptr = (TDataMember *) next())) {
             if (memberName == dmptr->GetName()) break;
          }
-         delete dlist;
          if (dmptr)
          {
             if (0) printf("It's a member!\n");
@@ -2332,8 +2330,6 @@ TClass *TTabCom::MakeClassFromVarName(const char varName[],
          while ((mptr = (TMethod *) next())) {
             if (strcmp(memberName.Data(),mptr->GetName())==0) break;
          }
-         delete mlist;
-
          if (mptr)
          {
             TString returnName = mptr->GetReturnTypeName();


### PR DESCRIPTION
Removed deletion of class Method list in core/rint/src/TTabCom.cxx and also removed unused data members list in the same function.