### PR TITLE
ROOT-7031 bug fix for macros which do not return when they ought to.

### DIFF
--- a/interpreter/cling/lib/Interpreter/IncrementalParser.cpp
+++ b/interpreter/cling/lib/Interpreter/IncrementalParser.cpp
@@ -753,6 +753,10 @@ namespace cling {
       setIgnore(clang::diag::warn_unused_comparison);
       setIgnore(clang::diag::ext_return_has_expr);
     }
+    auto setError = [&](clang::diag::kind Diag) {
+      Diags.setSeverity(Diag, diag::Severity::Error, SourceLocation());
+    };
+    setError(clang::diag::warn_falloff_nonvoid_function);
 
     Sema::SavePendingInstantiationsRAII SavedPendingInstantiations(S);
 

--- a/interpreter/cling/test/SourceCall/ErrorMacro.C
+++ b/interpreter/cling/test/SourceCall/ErrorMacro.C
@@ -1,0 +1,17 @@
+//------------------------------------------------------------------------------
+// CLING - the C++ LLVM-based InterpreterG :)
+//
+// This file is dual-licensed: you can choose to license it under the University
+// of Illinois Open Source License or the GNU Lesser General Public License. See
+// LICENSE.TXT for details.
+//------------------------------------------------------------------------------
+
+// RUN: cat %s | %cling -Xclang -verify 2>&1 | FileCheck %s
+
+.rawInput 1
+int example() { } // expected-error {{control reaches end of non-void function}}
+.rawInput 0
+// Make FileCheck happy with having at least one positive rule:
+int a = 5
+// CHECK: (int) 5
+.q


### PR DESCRIPTION
Turned the warning into an error, for macros which return nothing while they should. Changed warning into an error in DiagnosticSemaKinds.td and AnalysisBasedWarnings.cpp files. Also added lambda in IncrementalParser.cpp. 