### PR TITLE
ROOT-6902 bug fix for ClassDefNV and ClassDefOverride macros.

### DIFF
--- a/core/base/inc/Rtypes.h
+++ b/core/base/inc/Rtypes.h
@@ -244,16 +244,16 @@ public: \
    static int ImplFileLine(); \
    static const char *ImplFileName();
 
-#define _ClassDefInterp_(name,id) \
+#define _ClassDefInterp_(name,id,virtual_keyword, overrd) \
 private: \
 public: \
    static TClass *Class() { static TClass* sIsA = 0; if (!sIsA) sIsA = TClass::GetClass(#name); return sIsA; } \
    static const char *Class_Name() { return #name; } \
    static Version_t Class_Version() { return id; } \
    static TClass *Dictionary() { return 0; } \
-   virtual TClass *IsA() const { return name::Class(); } \
-   virtual void ShowMembers(TMemberInspector&insp) const { ::ROOT::Class_ShowMembers(name::Class(), this, insp); } \
-   virtual void Streamer(TBuffer&) { Error ("Streamer", "Cannot stream interpreted class."); } \
+   virtual_keyword TClass *IsA() const overrd { return name::Class(); } \
+   virtual_keyword void ShowMembers(TMemberInspector&insp) const overrd { ::ROOT::Class_ShowMembers(name::Class(), this, insp); } \
+   virtual_keyword void Streamer(TBuffer&) overrd { Error ("Streamer", "Cannot stream interpreted class."); } \
    void StreamerNVirtual(TBuffer&ClassDef_StreamerNVirtual_b) { name::Streamer(ClassDef_StreamerNVirtual_b); } \
    static const char *DeclFileName() { return __FILE__; } \
    static int ImplFileLine() { return 0; } \

--- a/core/meta/src/TCling.cxx
+++ b/core/meta/src/TCling.cxx
@@ -215,8 +215,29 @@ using namespace ROOT;
 namespace {
    static const std::string gInterpreterClassDef = "#undef ClassDef\n"
                 "#define ClassDef(name, id) \\\n"
-                "_ClassDefInterp_(name,id) \\\n"
+                "_ClassDefInterp_(name,id,virtual,) \\\n"
+                "static int DeclFileLine() { return __LINE__; } \n"
+                "#undef ClassDefNV\n"
+                "#define ClassDefNV(name, id) \\\n"
+                "_ClassDefInterp_(name,id,,) \\\n"
+                "static int DeclFileLine() { return __LINE__; }\n"
+                "#undef ClassDefOverride\n"
+                "#define ClassDefOverride(name, id) \\\n"
+                "_ClassDefInterp_(name,id,,override) \\\n"
                 "static int DeclFileLine() { return __LINE__; }\n";
+   static const std::string gNonInterpreterClassDef = "#define __ROOTCLING__ 1\n"
+               "#undef ClassDef\n"
+               "#define ClassDef(name,id) \\\n"
+               "_ClassDef_(name,id,virtual,) \\\n"
+               "static int DeclFileLine() { return __LINE__; }\n"
+               "#undef ClassDefNV\n"
+               "#define ClassDefNV(name, id)\\\n"
+               "_ClassDef_(name,id,,)\\\n"
+               "static int DeclFileLine() { return __LINE__; }\n"
+               "#undef ClassDefOverride\n"
+               "#define ClassDefOverride(name, id)\\\n"
+               "_ClassDef_(name,id,,override)\\\n"
+               "static int DeclFileLine() { return __LINE__; }\n";
 }
 
 R__EXTERN int optind;
@@ -1452,12 +1473,7 @@ void TCling::RegisterModule(const char* modulename,
    // FIXME: Remove #define __ROOTCLING__ once PCMs are there.
    // This is used to give Sema the same view on ACLiC'ed files (which
    // are then #included through the dictionary) as rootcling had.
-   TString code = fromRootCling ? "" :
-      "#define __ROOTCLING__ 1\n"
-      "#undef ClassDef\n"
-      "#define ClassDef(name,id) \\\n"
-      "_ClassDef_(name,id,virtual,) \\\n"
-      "static int DeclFileLine() { return __LINE__; }\n";
+   TString code = fromRootCling ? "" : gNonInterpreterClassDef ;
    code += payloadCode;
 
    // We need to open the dictionary shared library, to resolve sylbols
@@ -4976,11 +4992,7 @@ static cling::Interpreter::CompilationResult ExecAutoParse(const char *what,
    // wrapper function so the parent context must be the global.
    Sema::ContextAndScopeRAII pushedDCAndS(SemaR, C.getTranslationUnitDecl(),
                                           SemaR.TUScope);
-   std::string code = "#define __ROOTCLING__ 1\n"
-      "#undef ClassDef\n"
-      "#define ClassDef(name,id) \\\n"
-      "_ClassDef_(name,id,virtual,) \\\n"
-      "static int DeclFileLine() { return __LINE__; }\n";
+   std::string code = gNonInterpreterClassDef ;
    if (!header) {
       // This is the complete header file content and not the
       // name of a header.


### PR DESCRIPTION
Hello Axel. I hope it is ok now, I added as you said the gNonInterpreterClassDef string in namespace. And sorry, I made a new pull request because I wanted to change something I had pushed after the last commit..