### PR TITLE
Fixed TTreeReaderArray for classes containing a vector<built_in_type>.

### DIFF
--- a/tree/treeplayer/src/TTreeReaderArray.cxx
+++ b/tree/treeplayer/src/TTreeReaderArray.cxx
@@ -680,7 +680,10 @@ const char* ROOT::TTreeReaderArrayBase::GetBranchContentDataType(TBranch* branch
                   Error("GetBranchDataType()", "Could not get collection proxy from STL class");
                   return 0;
                }
+               // Try getting the contained class
                dict = myCollectionProxy->GetValueClass();
+               // If it fails, try to get the contained type as a primitive type
+               if (!dict) dict = TDataType::GetDataType(myCollectionProxy->GetType());
                if (!dict){
                   Error("GetBranchDataType()", "Could not get valueClass from collectionProxy.");
                   return 0;


### PR DESCRIPTION
Fixed an error that is occuring when accessing a branch of a class with a member of type vector<float> with a TTreeReaderArray. The error message was "Cannot determine the type contained in the collection of branch <branch_name>. That's weird - please report!". The problem was that GetValueClass() of the TVirtualCollectionProxy returned 0 because "float" is not a class. In such cases, i.e. for built-in types, GetType() should be used.