### PR TITLE
TTreeReaderArray can now read basic type arrays inside classes.

### DIFF
--- a/tree/treeplayer/src/TTreeReaderArray.cxx
+++ b/tree/treeplayer/src/TTreeReaderArray.cxx
@@ -508,6 +508,10 @@ void ROOT::TTreeReaderArrayBase::CreateProxy()
             else if (branchElement->GetType() == TBranchElement::kClonesMemberNode){
                fImpl = new TBasicTypeClonesReader(element->GetOffset());
             }
+            else {
+               fImpl = new TArrayFixedSizeReader(element->GetArrayLength());
+               ((TObjectArrayReader*)fImpl)->SetBasicTypeSize(((TDataType*)fDict)->Size());
+            }
          }
          else if (element->IsA() == TStreamerBase::Class()){
             fImpl = new TClonesReader();
@@ -683,6 +687,10 @@ const char* ROOT::TTreeReaderArrayBase::GetBranchContentDataType(TBranch* branch
             }
             else {
                dict = brElement->GetCurrentClass();
+               if (!dict) {
+                  TDictionary *myDataType = TDictionary::GetDictionary(brElement->GetTypeName());
+                  dict = TDataType::GetDataType((EDataType)((TDataType*)myDataType)->GetType());
+               }
                contentTypeName = brElement->GetTypeName();
                return 0;
             }


### PR DESCRIPTION
Given the following class (split):
class A {
   int arr[10];
};

TTreeReaderArray<int> could not access 'arr'. The issue is now fixed.