### PR TITLE
First commit for the Multiple Interpreters

### DIFF
--- a/interpreter/cling/include/cling/Interpreter/Interpreter.h
+++ b/interpreter/cling/include/cling/Interpreter/Interpreter.h
@@ -282,6 +282,17 @@ namespace cling {
     ///\param[in] llvmdir - ???
     ///\param[in] noRuntime - flag to control the presence of runtime universe
     Interpreter(int argc, const char* const *argv, const char* llvmdir = 0, bool noRuntime = false);
+
+    ///\brief Constructor for Interpreter.
+    ///
+    ///\param[in] argc - no. of args.
+    ///\param[in] argv - arguments passed when driver is invoked.
+    ///\param[in] llvmdir - ???
+    ///\param[in] noRuntime - flag to control the presence of runtime universe
+    ///\param[in] originalInterpreter - the master interpreter of this interpreter
+    Interpreter(Interpreter *originalInterpreter,int argc, const char* const *argv,
+                const char* llvmdir = 0, bool noRuntime = false);
+
     virtual ~Interpreter();
 
     const InvocationOptions& getOptions() const { return m_Opts; }
@@ -292,6 +303,10 @@ namespace cling {
     }
 
     llvm::LLVMContext* getLLVMContext() { return m_LLVMContext.get(); }
+
+    IncrementalExecutor* getIncrementalExecutor() { return m_Executor.get(); }
+
+    void setExternalIncrementalExecutor(IncrementalExecutor* extIncr);
 
     const LookupHelper& getLookupHelper() const { return *m_LookupHelper; }
 

--- a/interpreter/cling/include/cling/Interpreter/Interpreter.h
+++ b/interpreter/cling/include/cling/Interpreter/Interpreter.h
@@ -281,17 +281,21 @@ namespace cling {
     ///\param[in] argv - arguments passed when driver is invoked.
     ///\param[in] llvmdir - ???
     ///\param[in] noRuntime - flag to control the presence of runtime universe
-    Interpreter(int argc, const char* const *argv, const char* llvmdir = 0, bool noRuntime = false);
-
-    ///\brief Constructor for Interpreter.
+    ///\param[in] isChildInterp - flag to control if this is a child interpreter or not.
     ///
+    Interpreter(int argc, const char* const *argv,
+                const char* llvmdir = 0, bool noRuntime = false, bool isChildInterpreter = false);
+
+    ///\brief Constructor for child Interpreter.
+    ///\param[in] parentInterpreter - the  parent interpreter of this interpreter
     ///\param[in] argc - no. of args.
     ///\param[in] argv - arguments passed when driver is invoked.
     ///\param[in] llvmdir - ???
     ///\param[in] noRuntime - flag to control the presence of runtime universe
-    ///\param[in] originalInterpreter - the master interpreter of this interpreter
-    Interpreter(Interpreter *originalInterpreter,int argc, const char* const *argv,
-                const char* llvmdir = 0, bool noRuntime = false);
+    ///\param[in] isChildInterp - flag to control if this is a child interpreter or not.
+    ///
+    Interpreter(Interpreter &parentInterpreter,int argc, const char* const *argv,
+                const char* llvmdir = 0, bool noRuntime = true, bool isChildInterpreter = true);
 
     virtual ~Interpreter();
 
@@ -303,10 +307,6 @@ namespace cling {
     }
 
     llvm::LLVMContext* getLLVMContext() { return m_LLVMContext.get(); }
-
-    IncrementalExecutor* getIncrementalExecutor() { return m_Executor.get(); }
-
-    void setExternalIncrementalExecutor(IncrementalExecutor* extIncr);
 
     const LookupHelper& getLookupHelper() const { return *m_LookupHelper; }
 

--- a/interpreter/cling/include/cling/Utils/ASTImportSource.h
+++ b/interpreter/cling/include/cling/Utils/ASTImportSource.h
@@ -1,0 +1,88 @@
+#ifndef CLING_ASTIMPORTSOURCE_H
+#define CLING_ASTIMPORTSOURCE_H
+
+#include "cling/Interpreter/Interpreter.h"
+
+#include "clang/Frontend/CompilerInstance.h"
+#include "clang/Sema/Sema.h"
+#include "clang/AST/ASTContext.h"
+#include "clang/AST/ASTImporter.h"
+
+#include <string>
+#include <map>
+
+namespace clang {
+  class ASTContext;
+  class Expr;
+  class Decl;
+  class DeclContext;
+  class DeclarationName;
+  class GlobalDecl;
+  class FunctionDecl;
+  class IntegerLiteral;
+  class NamedDecl;
+  class NamespaceDecl;
+  class NestedNameSpecifier;
+  class QualType;
+  class Sema;
+  class TagDecl;
+  class TemplateDecl;
+  class Type;
+  class TypedefNameDecl;
+}
+
+namespace cling {
+  namespace utils {
+
+    class ASTImportSource : public clang::ExternalASTSource {
+
+      private:
+        cling::Interpreter *m_first_Interp;
+        cling::Interpreter *m_second_Interp;
+        const clang::TranslationUnitDecl *m_translationUnitI1;
+        const clang::TranslationUnitDecl *m_translationUnitI2;
+
+        clang::Sema *m_Sema;
+        /* A map for the DeclContext-to-DeclContext correspondence
+         * with DeclContexts pointers. */
+        std::map<const clang::DeclContext *, clang::DeclContext *> m_DeclContexts_map;
+        /* A map for all the imported Decls (Contexts). */
+        std::map <std::string, clang::DeclarationName> m_DeclName_map;
+
+      public:
+        ASTImportSource(cling::Interpreter *interpreter_first,
+                        cling::Interpreter *interpreter_second);
+
+        ~ASTImportSource() { };
+
+        bool
+          FindExternalVisibleDeclsByName(const clang::DeclContext *DC, clang::DeclarationName Name);
+
+        void InitializeSema(clang::Sema &S);
+
+        void ForgetSema();
+
+        bool Import(clang::DeclContext::lookup_result lookup_result,
+                    clang::ASTContext &from_ASTContext,
+                    clang::ASTContext &to_ASTContext,
+                    const clang::DeclContext *DC,
+                    clang::DeclarationName &Name,
+                    clang::DeclarationName &declNameI1);
+
+        void ImportDeclContext(clang::DeclContext *declContextFrom,
+                               clang::ASTImporter &importer,
+                               clang::DeclarationName &Name,
+                               clang::DeclarationName &declNameI1,
+                               const clang::DeclContext *DC);
+
+        void ImportDecl(clang::Decl *declFrom,
+                        clang::ASTImporter &importer,
+                        clang::DeclarationName &Name,
+                        clang::DeclarationName &declNameI1,
+                        const clang::DeclContext *DC);
+
+        cling::Interpreter *getInterpreter() { return m_first_Interp; }
+    };
+  } // end namespace utils
+} // end namespace cling
+#endif //CLING_ASTIMPORTSOURCE_H

--- a/interpreter/cling/lib/Interpreter/IncrementalExecutor.cpp
+++ b/interpreter/cling/lib/Interpreter/IncrementalExecutor.cpp
@@ -44,6 +44,7 @@ using namespace llvm;
 namespace cling {
 
 IncrementalExecutor::IncrementalExecutor(clang::DiagnosticsEngine& diags, const int& argc, const char* const *argv):
+  m_externalIncrementalExecutor(nullptr),
   m_CurrentAtExitModule(0)
 #if 0
   : m_Diags(diags)
@@ -122,6 +123,11 @@ std::unique_ptr<TargetMachine>
   return std::move(TM);
 }
 
+void IncrementalExecutor::setExternalIncrementalExecutor(IncrementalExecutor *extIncr) {
+  m_externalIncrementalExecutor = nullptr;
+  m_externalIncrementalExecutor = extIncr;
+}
+
 void IncrementalExecutor::shuttingDown() {
   // No need to protect this access, since hopefully there is no concurrent
   // shutdown request.
@@ -171,8 +177,12 @@ IncrementalExecutor::NotifyLazyFunctionCreators(const std::string& mangled_name)
     if (ret)
       return ret;
   }
+  llvm::StringRef name(mangled_name);
+  void *address = nullptr;
+  if(m_externalIncrementalExecutor)
+   address = m_externalIncrementalExecutor->getAddressOfGlobal(name);
 
-  return HandleMissingFunction(mangled_name);
+  return (address ? address : HandleMissingFunction(mangled_name));
 }
 
 #if 0

--- a/interpreter/cling/lib/Interpreter/IncrementalExecutor.cpp
+++ b/interpreter/cling/lib/Interpreter/IncrementalExecutor.cpp
@@ -125,7 +125,8 @@ std::unique_ptr<TargetMachine>
 
 void IncrementalExecutor::setExternalIncrementalExecutor(IncrementalExecutor *extIncr) {
   m_externalIncrementalExecutor = nullptr;
-  m_externalIncrementalExecutor = extIncr;
+  if (extIncr != nullptr)
+    m_externalIncrementalExecutor = extIncr;
 }
 
 void IncrementalExecutor::shuttingDown() {

--- a/interpreter/cling/lib/Interpreter/IncrementalExecutor.h
+++ b/interpreter/cling/lib/Interpreter/IncrementalExecutor.h
@@ -48,7 +48,8 @@ namespace cling {
     ///
     std::unique_ptr<IncrementalJIT> m_JIT;
 
-    // A pointer to the IncrementalExecutor of the "master" interpreter.
+    ///\brier A pointer to the IncrementalExecutor of the parent Interpreter.
+    ///
     IncrementalExecutor* m_externalIncrementalExecutor;
 
     ///\brief Helper that manages when the destructor of an object to be called.

--- a/interpreter/cling/lib/Interpreter/IncrementalExecutor.h
+++ b/interpreter/cling/lib/Interpreter/IncrementalExecutor.h
@@ -48,6 +48,9 @@ namespace cling {
     ///
     std::unique_ptr<IncrementalJIT> m_JIT;
 
+    // A pointer to the IncrementalExecutor of the "master" interpreter.
+    IncrementalExecutor* m_externalIncrementalExecutor;
+
     ///\brief Helper that manages when the destructor of an object to be called.
     ///
     /// The object is registered first as an CXAAtExitElement and then cling
@@ -140,6 +143,8 @@ namespace cling {
     IncrementalExecutor(clang::DiagnosticsEngine& diags, const int& argc, const char* const *argv);
 
     ~IncrementalExecutor();
+
+    void setExternalIncrementalExecutor(IncrementalExecutor* extIncr);
 
     void installLazyFunctionCreator(LazyFunctionCreatorFunc_t fp);
 

--- a/interpreter/cling/lib/Interpreter/IncrementalParser.cpp
+++ b/interpreter/cling/lib/Interpreter/IncrementalParser.cpp
@@ -157,7 +157,7 @@ namespace {
 namespace cling {
   IncrementalParser::IncrementalParser(Interpreter* interp,
                                        int argc, const char* const *argv,
-                                       const char* llvmdir):
+                                       const char* llvmdir, bool isChildInterpreter):
     m_Interpreter(interp), m_Consumer(0), m_ModuleNo(0) {
 
     CompilerInstance* CI = CIFactory::createCI("", argc, argv, llvmdir);
@@ -193,7 +193,7 @@ namespace cling {
     WrapperTransformers.emplace_back(new ValuePrinterSynthesizer(TheSema, 0));
     WrapperTransformers.emplace_back(new DeclExtractor(TheSema));
     WrapperTransformers.emplace_back(new NullDerefProtectionTransformer(TheSema));
-    WrapperTransformers.emplace_back(new ValueExtractionSynthesizer(TheSema));
+    WrapperTransformers.emplace_back(new ValueExtractionSynthesizer(TheSema, isChildInterpreter));
     WrapperTransformers.emplace_back(new CheckEmptyTransactionTransformer(TheSema));
 
     m_Consumer->SetTransformers(std::move(ASTTransformers),
@@ -202,7 +202,7 @@ namespace cling {
 
   void
   IncrementalParser::Initialize(llvm::SmallVectorImpl<ParseResultTransaction>&
-                                result, bool slaveInterp) {
+                                result, bool childInterp) {
     m_TransactionPool.reset(new TransactionPool(getCI()->getSema()));
     if (hasCodeGenerator()) {
       getCodeGenerator()->Initialize(getCI()->getASTContext());
@@ -247,9 +247,9 @@ namespace cling {
     if (External)
       External->StartTranslationUnit(m_Consumer);
 
-    // If I am the master Interpreter, only then do the #include <new>
-    if (!slaveInterp)
-      if (m_CI->getLangOpts().CPlusPlus) {
+    /* If I belong to the parent Interpreter, only then do
+     * the #include <new> */
+    if (!childInterp && m_CI->getLangOpts().CPlusPlus) {
         // <new> is needed by the ValuePrinter so it's a good thing to include it.
         // We need to include it to determine the version number of the standard
         // library implementation.

--- a/interpreter/cling/lib/Interpreter/IncrementalParser.h
+++ b/interpreter/cling/lib/Interpreter/IncrementalParser.h
@@ -105,7 +105,8 @@ namespace cling {
                       const char* llvmdir);
     ~IncrementalParser();
 
-    void Initialize(llvm::SmallVectorImpl<ParseResultTransaction>& result);
+    void Initialize(llvm::SmallVectorImpl<ParseResultTransaction>& result,
+                    bool slaveInterp = false);
     clang::CompilerInstance* getCI() const { return m_CI.get(); }
     clang::Parser* getParser() const { return m_Parser.get(); }
     clang::CodeGenerator* getCodeGenerator() const { return m_CodeGen.get(); }

--- a/interpreter/cling/lib/Interpreter/IncrementalParser.h
+++ b/interpreter/cling/lib/Interpreter/IncrementalParser.h
@@ -102,7 +102,7 @@ namespace cling {
     typedef llvm::PointerIntPair<Transaction*, 2, EParseResult>
       ParseResultTransaction;
     IncrementalParser(Interpreter* interp, int argc, const char* const *argv,
-                      const char* llvmdir);
+                      const char* llvmdir, bool isChildInterpreter = false);
     ~IncrementalParser();
 
     void Initialize(llvm::SmallVectorImpl<ParseResultTransaction>& result,

--- a/interpreter/cling/lib/Interpreter/Interpreter.cpp
+++ b/interpreter/cling/lib/Interpreter/Interpreter.cpp
@@ -224,6 +224,72 @@ namespace cling {
     setCallbacks(std::move(AutoLoadCB));
   }
 
+  //Overloading the Interpreter constructor by passing one more argument, the pointer
+  //to the "master" Interpreter.
+  Interpreter::Interpreter(Interpreter *originalInterpreter, int argc, const char* const *argv,
+                           const char* llvmdir /*= 0*/, bool noRuntime) :
+    m_UniqueCounter(0), m_PrintDebug(false), m_DynamicLookupDeclared(false),
+    m_DynamicLookupEnabled(false), m_RawInputEnabled(false) {
+
+    m_LLVMContext.reset(new llvm::LLVMContext);
+    std::vector<unsigned> LeftoverArgsIdx;
+    m_Opts = InvocationOptions::CreateFromArgs(argc, argv, LeftoverArgsIdx);
+    std::vector<const char*> LeftoverArgs;
+
+    for (size_t I = 0, N = LeftoverArgsIdx.size(); I < N; ++I) {
+      LeftoverArgs.push_back(argv[LeftoverArgsIdx[I]]);
+    }
+
+    m_DyLibManager.reset(new DynamicLibraryManager(getOptions()));
+
+    m_IncrParser.reset(new IncrementalParser(this, LeftoverArgs.size(),
+                                             &LeftoverArgs[0],
+                                             llvmdir));
+
+    Sema& SemaRef = getSema();
+    Preprocessor& PP = SemaRef.getPreprocessor();
+    // Enable incremental processing, which prevents the preprocessor destroying
+    // the lexer on EOF token.
+    PP.enableIncrementalProcessing();
+
+    m_LookupHelper.reset(new LookupHelper(new Parser(PP, SemaRef,
+      /*SkipFunctionBodies*/false,
+      /*isTemp*/true), this));
+
+    if (!isInSyntaxOnlyMode())
+      m_Executor.reset(new IncrementalExecutor(SemaRef.Diags, argc, argv));
+
+    // Tell the diagnostic client that we are entering file parsing mode.
+    DiagnosticConsumer& DClient = getCI()->getDiagnosticClient();
+    DClient.BeginSourceFile(getCI()->getLangOpts(), &PP);
+
+    llvm::SmallVector<IncrementalParser::ParseResultTransaction, 2>
+      IncrParserTransactions;
+    m_IncrParser->Initialize(IncrParserTransactions, true);
+
+    handleFrontendOptions();
+
+    AddRuntimeIncludePaths(argv[0]);
+
+    //The "slave" Interpreter doesn't set the runtime environment.
+    /*if (!noRuntime) {
+      if (getCI()->getLangOpts().CPlusPlus)
+        IncludeCXXRuntime();
+      else
+        IncludeCRuntime();
+    }*/
+
+    // Commit the transactions, now that gCling is set up. It is needed for
+    // static initialization in these transactions through local_cxa_atexit().
+    for (auto&& I: IncrParserTransactions)
+      m_IncrParser->commitTransaction(I);
+    // Disable suggestions for ROOT
+    bool showSuggestions = !llvm::StringRef(ClingStringify(CLING_VERSION)).startswith("ROOT");
+    std::unique_ptr<InterpreterCallbacks>
+      AutoLoadCB(new AutoloadCallback(this, showSuggestions));
+    setCallbacks(std::move(AutoLoadCB));
+  }
+
   Interpreter::~Interpreter() {
     if (m_Executor)
       m_Executor->shuttingDown();
@@ -235,6 +301,11 @@ namespace cling {
     // explicitly, before the implicit destruction (through the unique_ptr) of
     // the callbacks.
     m_IncrParser.reset(0);
+  }
+
+  // Set the pointer to the IncrementalExecutor of my master Interpreter.
+  void Interpreter::setExternalIncrementalExecutor(IncrementalExecutor *extIncr) {
+   m_Executor->setExternalIncrementalExecutor(extIncr);
   }
 
   const char* Interpreter::getVersion() const {

--- a/interpreter/cling/lib/Interpreter/ValueExtractionSynthesizer.cpp
+++ b/interpreter/cling/lib/Interpreter/ValueExtractionSynthesizer.cpp
@@ -277,7 +277,7 @@ namespace {
     else if (desugaredTy->isRecordType() || desugaredTy->isConstantArrayType()
              || desugaredTy->isMemberPointerType()) {
       // 2) object types :
-      // check existance of copy constructor before call
+      // check existence of copy constructor before call
       if (!desugaredTy->isMemberPointerType()
           && !availableCopyConstructor(desugaredTy, m_Sema))
         return E;
@@ -420,7 +420,7 @@ namespace {
     R.clear();
     R.setLookupName(&m_Context->Idents.get("copyArray"));
     m_Sema->LookupQualifiedName(R, NSD);
-    assert(!R.empty() && "Cannot find cling::runtime::internal::copyArray");
+    //assert(!R.empty() && "Cannot find cling::runtime::internal::copyArray");
     m_UnresolvedCopyArray
       = m_Sema->BuildDeclarationNameExpr(CSS, R, /*ADL*/ false).get();
   }

--- a/interpreter/cling/lib/Interpreter/ValueExtractionSynthesizer.h
+++ b/interpreter/cling/lib/Interpreter/ValueExtractionSynthesizer.h
@@ -45,12 +45,16 @@ namespace cling {
     ///
     clang::Expr* m_UnresolvedCopyArray;
 
+    bool m_isChildInterpreter;
+
 public:
     ///\ brief Constructs the return synthesizer.
     ///
     ///\param[in] S - The semantic analysis object.
+    ///\param[in] isChildInterpreter - flag to control if it is called
+    /// from a child or parent Interpreter
     ///
-    ValueExtractionSynthesizer(clang::Sema* S);
+    ValueExtractionSynthesizer(clang::Sema* S, bool isChildInterpreter);
 
     virtual ~ValueExtractionSynthesizer();
 

--- a/interpreter/cling/lib/Utils/ASTImportSource.cpp
+++ b/interpreter/cling/lib/Utils/ASTImportSource.cpp
@@ -4,95 +4,86 @@ using namespace clang;
 
 namespace cling {
   namespace utils {
-    ASTImportSource::ASTImportSource(cling::Interpreter *interpreter_first,
-                                     cling::Interpreter *interpreter_second) :
-      m_first_Interp(interpreter_first), m_second_Interp(interpreter_second) {
-
-      m_translationUnitI1 = m_first_Interp->getCI()->getASTContext().getTranslationUnitDecl();
-      m_translationUnitI2 = m_second_Interp->getCI()->getASTContext().getTranslationUnitDecl();
-
+    ASTImportSource::ASTImportSource(cling::Interpreter *parent_interpreter,
+                                     cling::Interpreter *child_interpreter) :
+      m_parent_Interp(parent_interpreter), m_child_Interp(child_interpreter) {
     }
 
-    void ASTImportSource::InitializeSema(Sema &S) {
-      m_Sema = &S;
-    }
-
-    void ASTImportSource::ForgetSema() {
-      m_Sema = nullptr;
-    }
-
-    void ASTImportSource::ImportDecl(Decl *declFrom,
+    void ASTImportSource::ImportDecl(Decl *declToImport,
                                      ASTImporter &importer,
-                                     DeclarationName &Name,
-                                     DeclarationName &declNameI1,
-                                     const DeclContext *DC) {
+                                     DeclarationName &childDeclName,
+                                     DeclarationName &parentDeclName,
+                                     const DeclContext *childCurrentDeclContext) {
 
       Decl *importedDecl = nullptr;
       /* Don't do the import if we have a Function Template.
        * Not supported by clang. */
-      if (!(declFrom->isFunctionOrFunctionTemplate() && declFrom->isTemplateDecl()))
-        importedDecl = importer.Import(declFrom);
+      if (!(declToImport->isFunctionOrFunctionTemplate() && declToImport->isTemplateDecl()))
+        importedDecl = importer.Import(declToImport);
 
       if (importedDecl) {
         /* Import this Decl in the map we own. Not used for now
-         * m_Decls_map[Name.getAsString()] = std::make_pair(importedDecl, declFrom); */
+         * m_Decls_map[Name.getAsString()] = std::make_pair(importedDecl, declToImport); */
         std::vector < NamedDecl * > declVector;
         declVector.push_back((NamedDecl *) importedDecl);
         llvm::ArrayRef < NamedDecl * > FoundDecls(declVector);
-        SetExternalVisibleDeclsForName(DC, ((NamedDecl *) importedDecl)->getDeclName(),
+        SetExternalVisibleDeclsForName(childCurrentDeclContext,
+                                       ((NamedDecl *) importedDecl)->getDeclName(),
                                        FoundDecls);
 
-        /* And also put the Decl I found from the first Interpreter
-         * in the map of the second Interpreter to have it for the future. */
-        m_DeclName_map[Name.getAsString()] = declNameI1;
+        /* And also put the Decl I found from the parent Interpreter
+         * in the map of the child Interpreter to have it for the future. */
+        m_DeclName_map[childDeclName.getAsString()] = parentDeclName;
       }
     }
 
-    void ASTImportSource::ImportDeclContext(DeclContext *declContextFrom,
+    void ASTImportSource::ImportDeclContext(DeclContext *declContextToImport,
                                             ASTImporter &importer,
-                                            DeclarationName &Name,
-                                            DeclarationName &declNameI1,
-                                            const DeclContext *DC) {
+                                            DeclarationName &childDeclName,
+                                            DeclarationName &parentDeclName,
+                                            const DeclContext *childCurrentDeclContext) {
 
       DeclContext *importedDeclContext =
-        importer.ImportContext(declContextFrom);
+        importer.ImportContext(declContextToImport);
 
       if (importedDeclContext) {
-        /* And also put the declaration context I found from the first Interpreter
-         * in the map of the second Interpreter to have it for the future. */
-        m_DeclContexts_map[importedDeclContext] = declContextFrom;
+        /* And also put the declaration context I found from the parent Interpreter
+         * in the map of the child Interpreter to have it for the future. */
+        m_DeclContexts_map[importedDeclContext] = declContextToImport;
 
         /* Not used for now.
-         * m_DeclContextsNames_map[Name.getAsString()] =
-         * std::make_pair(importedDeclContext,declContextFrom); */
+         * m_DeclContextsNames_map[childDeclName.getAsString()] =
+         * std::make_pair(importedDeclContext,declContextToImport); */
         importedDeclContext->setHasExternalVisibleStorage(true);
 
         std::vector < NamedDecl * > declVector;
         declVector.push_back((NamedDecl *) importedDeclContext);
         llvm::ArrayRef < NamedDecl * > FoundDecls(declVector);
-        SetExternalVisibleDeclsForName(DC, ((NamedDecl *) importedDeclContext)->getDeclName(),
+        SetExternalVisibleDeclsForName(childCurrentDeclContext,
+                                       ((NamedDecl *) importedDeclContext)->getDeclName(),
                                        FoundDecls);
 
-        /* And also put the Decl I found from the first Interpreter
-         * in the map of the second Interpreter to have it for the future. */
-        m_DeclName_map[Name.getAsString()] = declNameI1;
+        /* And also put the Decl I found from the parent Interpreter
+         * in the map of the child Interpreter to have it for the future. */
+        m_DeclName_map[childDeclName.getAsString()] = parentDeclName;
       }
     }
 
     bool ASTImportSource::Import(DeclContext::lookup_result lookup_result,
                                  ASTContext &from_ASTContext,
                                  ASTContext &to_ASTContext,
-                                 const DeclContext *DC,
-                                 DeclarationName &Name,
-                                 DeclarationName &declNameI1) {
+                                 const DeclContext *childCurrentDeclContext,
+                                 DeclarationName &childDeclName,
+                                 DeclarationName &parentDeclName) {
 
-      /* Check if we found this Name in the first interpreter */
+      /* Check if we found this Name in the parent interpreter */
       if (lookup_result.empty())
         return false;
 
       /* Prepare to import the Decl(Context)  we found in the
-       * second interpreter */
-      FileManager& fm =  m_second_Interp->getCI()->getFileManager();
+       * child interpreter */
+      const FileSystemOptions systemOptions;
+      FileManager fm(systemOptions, nullptr);
 
       /*****************************ASTImporter**********************************/
       ASTImporter importer(to_ASTContext, fm, from_ASTContext, fm,
@@ -102,9 +93,10 @@ namespace cling {
       /* If this Name we are looking for is for example a Namespace,
        * then it is a Decl Context. */
       if ((*lookup_result.data())->getKind() == Decl::Namespace) {
-        DeclContext *declContextFrom =
+        DeclContext *declContextToImport =
           llvm::cast<DeclContext>(*lookup_result.data());
-        ImportDeclContext(declContextFrom, importer, Name, declNameI1, DC);
+        ImportDeclContext(declContextToImport, importer, childDeclName,
+                          parentDeclName, childCurrentDeclContext);
       } else { /* If this name is just a Decl. */
         /* Check if we have more than one results, this means that it
          * may be an overloaded function. */
@@ -113,67 +105,82 @@ namespace cling {
           DeclContext::lookup_iterator E;
           for (I = lookup_result.begin(), E = lookup_result.end(); I != E; ++I) {
             NamedDecl *D = *I;
-            Decl *declFrom = llvm::cast<Decl>(D);
-            ImportDecl(declFrom, importer, Name, declNameI1, DC);
+            Decl *declToImport = llvm::cast<Decl>(D);
+            ImportDecl(declToImport, importer, childDeclName,
+                       parentDeclName, childCurrentDeclContext);
           }
         } else {
-          Decl *declFrom = llvm::cast<Decl>(*lookup_result.data());
-          ImportDecl(declFrom, importer, Name, declNameI1, DC);
+          Decl *declToImport = llvm::cast<Decl>(*lookup_result.data());
+          ImportDecl(declToImport, importer, childDeclName,
+                     parentDeclName, childCurrentDeclContext);
         }
       }
       return true;
     }
 
-    bool ASTImportSource::FindExternalVisibleDeclsByName(const DeclContext *DC,
-                                                         DeclarationName Name) {
-      assert(DC->hasExternalVisibleStorage() &&
+    ///\brief This is the most important function of the class ASTImportSource
+    /// since from here initiates the lookup and import part of the missing
+    /// Decl(s) (Contexts).
+    ///
+    bool ASTImportSource::FindExternalVisibleDeclsByName(
+      const DeclContext *childCurrentDeclContext, DeclarationName childDeclName) {
+
+      assert(childCurrentDeclContext->hasExternalVisibleStorage() &&
              "DeclContext has no visible decls in storage");
 
       /* clang will call FindExternalVisibleDeclsByName with an
-       * IdentifierInfo valid for the second interpreter. Get the
+       * IdentifierInfo valid for the child interpreter. Get the
        * IdentifierInfo's StringRef representation.
-       * Get the identifier info from the first interpreter
+       * Get the identifier info from the parent interpreter
        * for this Name. */
-      llvm::StringRef name(Name.getAsString());
-      IdentifierTable &identsI1 =
-        m_first_Interp->getCI()->getASTContext().Idents;
-      IdentifierInfo &IdentifierInfoI1 = identsI1.get(name);
-      DeclarationName declNameI1(&IdentifierInfoI1);
+      llvm::StringRef name(childDeclName.getAsString());
+      IdentifierTable &parentIdentifierTable =
+        m_parent_Interp->getCI()->getASTContext().Idents;
+      IdentifierInfo &parentIdentifierInfo = parentIdentifierTable.get(name);
+      DeclarationName parentDeclName(&parentIdentifierInfo);
 
       /* Check if we have already imported this Decl (Context). */
-      if (m_DeclName_map.find(Name.getAsString()) != m_DeclName_map.end())
+      if (m_DeclName_map.find(childDeclName.getAsString()) != m_DeclName_map.end())
         return true;
 
       DeclContext::lookup_result lookup_result;
       /* If we are not looking for this Name in the Translation Unit
        * but instead inside a namespace, */
-      if (!DC->isTranslationUnit()) {
+      if (!childCurrentDeclContext->isTranslationUnit()) {
         /* Search in the map of the stored Decl Contexts for this
          * namespace. */
-        if (m_DeclContexts_map.find(DC) != m_DeclContexts_map.end()) {
-          /* If DC was found before and is already in the map,
+        if (m_DeclContexts_map.find(childCurrentDeclContext) != m_DeclContexts_map.end()) {
+          /* If childCurrentDeclContext was found before and is already in the map,
            * then do the lookup using the stored pointer. */
-          DeclContext *originalDeclContext = m_DeclContexts_map.find(DC)->second;
+          DeclContext *originalDeclContext =
+            m_DeclContexts_map.find(childCurrentDeclContext)->second;
 
           Decl *fromDeclContext = Decl::castFromDeclContext(originalDeclContext);
           ASTContext &from_ASTContext = fromDeclContext->getASTContext();
 
-          Decl *toDeclContext = Decl::castFromDeclContext(DC);
+          Decl *toDeclContext = Decl::castFromDeclContext(childCurrentDeclContext);
           ASTContext &to_ASTContext = toDeclContext->getASTContext();
 
-          lookup_result = originalDeclContext->lookup(declNameI1);
+          lookup_result = originalDeclContext->lookup(parentDeclName);
           /* Do the import */
-          if (Import(lookup_result, from_ASTContext, to_ASTContext, DC, Name, declNameI1))
+          if (Import(lookup_result, from_ASTContext, to_ASTContext,
+                     childCurrentDeclContext, childDeclName, parentDeclName))
             return true;
         }
       } else { /* Otherwise search in the Translation Unit. */
-        ASTContext &from_ASTContext = m_translationUnitI1->getASTContext();
-        ASTContext &to_ASTContext = m_translationUnitI2->getASTContext();
-        DeclContext *TUDeclContextI1 = TranslationUnitDecl::castToDeclContext(m_translationUnitI1);
+        ASTContext &from_ASTContext = m_parent_Interp->getCI()->getASTContext();
+        ASTContext &to_ASTContext = m_child_Interp->getCI()->getASTContext();
 
-        lookup_result = TUDeclContextI1->lookup(declNameI1);
+        /* Do the lookup in the Translation Unit of parent Interpreter */
+        DeclContext *parentTUDeclContext =
+          TranslationUnitDecl::castToDeclContext(from_ASTContext.getTranslationUnitDecl());
+
+        //to_ASTContext.getTranslationUnitDecl()
+
+        lookup_result = parentTUDeclContext->lookup(parentDeclName);
         /* Do the import */
-        if (Import(lookup_result, from_ASTContext, to_ASTContext, DC, Name, declNameI1))
+        if (Import(lookup_result, from_ASTContext, to_ASTContext,
+                   childCurrentDeclContext, childDeclName, parentDeclName))
           return true;
       }
       return false;

--- a/interpreter/cling/lib/Utils/ASTImportSource.cpp
+++ b/interpreter/cling/lib/Utils/ASTImportSource.cpp
@@ -1,0 +1,182 @@
+#include "cling/Utils/ASTImportSource.h"
+
+using namespace clang;
+
+namespace cling {
+  namespace utils {
+    ASTImportSource::ASTImportSource(cling::Interpreter *interpreter_first,
+                                     cling::Interpreter *interpreter_second) :
+      m_first_Interp(interpreter_first), m_second_Interp(interpreter_second) {
+
+      m_translationUnitI1 = m_first_Interp->getCI()->getASTContext().getTranslationUnitDecl();
+      m_translationUnitI2 = m_second_Interp->getCI()->getASTContext().getTranslationUnitDecl();
+
+    }
+
+    void ASTImportSource::InitializeSema(Sema &S) {
+      m_Sema = &S;
+    }
+
+    void ASTImportSource::ForgetSema() {
+      m_Sema = nullptr;
+    }
+
+    void ASTImportSource::ImportDecl(Decl *declFrom,
+                                     ASTImporter &importer,
+                                     DeclarationName &Name,
+                                     DeclarationName &declNameI1,
+                                     const DeclContext *DC) {
+
+      Decl *importedDecl = nullptr;
+      /* Don't do the import if we have a Function Template.
+       * Not supported by clang. */
+      if (!(declFrom->isFunctionOrFunctionTemplate() && declFrom->isTemplateDecl()))
+        importedDecl = importer.Import(declFrom);
+
+      if (importedDecl) {
+        /* Import this Decl in the map we own. Not used for now
+         * m_Decls_map[Name.getAsString()] = std::make_pair(importedDecl, declFrom); */
+        std::vector < NamedDecl * > declVector;
+        declVector.push_back((NamedDecl *) importedDecl);
+        llvm::ArrayRef < NamedDecl * > FoundDecls(declVector);
+        SetExternalVisibleDeclsForName(DC, ((NamedDecl *) importedDecl)->getDeclName(),
+                                       FoundDecls);
+
+        /* And also put the Decl I found from the first Interpreter
+         * in the map of the second Interpreter to have it for the future. */
+        m_DeclName_map[Name.getAsString()] = declNameI1;
+      }
+    }
+
+    void ASTImportSource::ImportDeclContext(DeclContext *declContextFrom,
+                                            ASTImporter &importer,
+                                            DeclarationName &Name,
+                                            DeclarationName &declNameI1,
+                                            const DeclContext *DC) {
+
+      DeclContext *importedDeclContext =
+        importer.ImportContext(declContextFrom);
+
+      if (importedDeclContext) {
+        /* And also put the declaration context I found from the first Interpreter
+         * in the map of the second Interpreter to have it for the future. */
+        m_DeclContexts_map[importedDeclContext] = declContextFrom;
+
+        /* Not used for now.
+         * m_DeclContextsNames_map[Name.getAsString()] =
+         * std::make_pair(importedDeclContext,declContextFrom); */
+        importedDeclContext->setHasExternalVisibleStorage(true);
+
+        std::vector < NamedDecl * > declVector;
+        declVector.push_back((NamedDecl *) importedDeclContext);
+        llvm::ArrayRef < NamedDecl * > FoundDecls(declVector);
+        SetExternalVisibleDeclsForName(DC, ((NamedDecl *) importedDeclContext)->getDeclName(),
+                                       FoundDecls);
+
+        /* And also put the Decl I found from the first Interpreter
+         * in the map of the second Interpreter to have it for the future. */
+        m_DeclName_map[Name.getAsString()] = declNameI1;
+      }
+    }
+
+    bool ASTImportSource::Import(DeclContext::lookup_result lookup_result,
+                                 ASTContext &from_ASTContext,
+                                 ASTContext &to_ASTContext,
+                                 const DeclContext *DC,
+                                 DeclarationName &Name,
+                                 DeclarationName &declNameI1) {
+
+      /* Check if we found this Name in the first interpreter */
+      if (lookup_result.empty())
+        return false;
+
+      /* Prepare to import the Decl(Context)  we found in the
+       * second interpreter */
+      FileManager& fm =  m_second_Interp->getCI()->getFileManager();
+
+      /*****************************ASTImporter**********************************/
+      ASTImporter importer(to_ASTContext, fm, from_ASTContext, fm,
+        /*MinimalImport : ON*/ true);
+      /**************************************************************************/
+
+      /* If this Name we are looking for is for example a Namespace,
+       * then it is a Decl Context. */
+      if ((*lookup_result.data())->getKind() == Decl::Namespace) {
+        DeclContext *declContextFrom =
+          llvm::cast<DeclContext>(*lookup_result.data());
+        ImportDeclContext(declContextFrom, importer, Name, declNameI1, DC);
+      } else { /* If this name is just a Decl. */
+        /* Check if we have more than one results, this means that it
+         * may be an overloaded function. */
+        if (lookup_result.size() > 1) {
+          DeclContext::lookup_iterator I;
+          DeclContext::lookup_iterator E;
+          for (I = lookup_result.begin(), E = lookup_result.end(); I != E; ++I) {
+            NamedDecl *D = *I;
+            Decl *declFrom = llvm::cast<Decl>(D);
+            ImportDecl(declFrom, importer, Name, declNameI1, DC);
+          }
+        } else {
+          Decl *declFrom = llvm::cast<Decl>(*lookup_result.data());
+          ImportDecl(declFrom, importer, Name, declNameI1, DC);
+        }
+      }
+      return true;
+    }
+
+    bool ASTImportSource::FindExternalVisibleDeclsByName(const DeclContext *DC,
+                                                         DeclarationName Name) {
+      assert(DC->hasExternalVisibleStorage() &&
+             "DeclContext has no visible decls in storage");
+
+      /* clang will call FindExternalVisibleDeclsByName with an
+       * IdentifierInfo valid for the second interpreter. Get the
+       * IdentifierInfo's StringRef representation.
+       * Get the identifier info from the first interpreter
+       * for this Name. */
+      llvm::StringRef name(Name.getAsString());
+      IdentifierTable &identsI1 =
+        m_first_Interp->getCI()->getASTContext().Idents;
+      IdentifierInfo &IdentifierInfoI1 = identsI1.get(name);
+      DeclarationName declNameI1(&IdentifierInfoI1);
+
+      /* Check if we have already imported this Decl (Context). */
+      if (m_DeclName_map.find(Name.getAsString()) != m_DeclName_map.end())
+        return true;
+
+      DeclContext::lookup_result lookup_result;
+      /* If we are not looking for this Name in the Translation Unit
+       * but instead inside a namespace, */
+      if (!DC->isTranslationUnit()) {
+        /* Search in the map of the stored Decl Contexts for this
+         * namespace. */
+        if (m_DeclContexts_map.find(DC) != m_DeclContexts_map.end()) {
+          /* If DC was found before and is already in the map,
+           * then do the lookup using the stored pointer. */
+          DeclContext *originalDeclContext = m_DeclContexts_map.find(DC)->second;
+
+          Decl *fromDeclContext = Decl::castFromDeclContext(originalDeclContext);
+          ASTContext &from_ASTContext = fromDeclContext->getASTContext();
+
+          Decl *toDeclContext = Decl::castFromDeclContext(DC);
+          ASTContext &to_ASTContext = toDeclContext->getASTContext();
+
+          lookup_result = originalDeclContext->lookup(declNameI1);
+          /* Do the import */
+          if (Import(lookup_result, from_ASTContext, to_ASTContext, DC, Name, declNameI1))
+            return true;
+        }
+      } else { /* Otherwise search in the Translation Unit. */
+        ASTContext &from_ASTContext = m_translationUnitI1->getASTContext();
+        ASTContext &to_ASTContext = m_translationUnitI2->getASTContext();
+        DeclContext *TUDeclContextI1 = TranslationUnitDecl::castToDeclContext(m_translationUnitI1);
+
+        lookup_result = TUDeclContextI1->lookup(declNameI1);
+        /* Do the import */
+        if (Import(lookup_result, from_ASTContext, to_ASTContext, DC, Name, declNameI1))
+          return true;
+      }
+      return false;
+    }
+  } // end namespace utils
+} // end namespace cling

--- a/interpreter/cling/lib/Utils/CMakeLists.txt
+++ b/interpreter/cling/lib/Utils/CMakeLists.txt
@@ -8,6 +8,7 @@
 
 add_cling_library(clingUtils
   AST.cpp
+  ASTImportSource.cpp
 
   LINK_LIBS
   clangCodeGen

--- a/interpreter/llvm/src/tools/clang/lib/Sema/SemaOpenMP.cpp
+++ b/interpreter/llvm/src/tools/clang/lib/Sema/SemaOpenMP.cpp
@@ -105,7 +105,7 @@ private:
           ConstructLoc(), OrderedRegion(false), InnerTeamsRegionLoc() {}
   };
 
-  typedef SmallVector<SharingMapTy, 64> StackTy;
+  typedef SmallVector<SharingMapTy, 4> StackTy;
 
   /// \brief Stack of used declaration and their data-sharing attributes.
   StackTy Stack;


### PR DESCRIPTION
First commit for the Multiple Interpreters.
--------------------------------------------------------
--------------------------------------------------------

ASTImportSource.cpp, ASTImportSource.h
--------------------------------------------------------------
The class that implements the importing functionalities for the multiple Interpreters.
It derives from the clang class ExternalASTSource, and overrides the function  FindExternalVisibleDeclsByname which does the search and importing of the ASTNodes by  calling the clang::ASTImporter.
This class must be created when setting up the second Interpreter and “passed” to its Translation Unit with the function setExternalSource.

Symbol Resolution from the execution engine of the second interpreter.
---------------------------------------------------------------------------------------------------
In order for the second Interpreter to find and execute the correct functions that are defined in the first Interpreter, but are called from the second, the following changes have been made in the classes of IncrementalExecutor and Interpreter.

(IncrementalExecutor.cpp, IncrementalExecutor.h, Interpreter.cpp, Interpreter.h)

-Added a pointer to an 'external' IncrementalExecutor in IncrementalExecutor class, and a corresponding function to set the pointer (IncrementalExecutor::setExternalIncrementalExecutor).
    
-Added in Interpreter a getIncrementalExecutor() function to get a pointer to its IncrementalExecutor.
    
-Added in Interpreter a function Interpreter::setExternalIncrementalExecutor which calls IncrementalExecutor's setExternalIncrementalExecutor function.
    
 -Edited IncrementalExecutor::NotifyLazyFunctionCreators to search for the address of a missing symbol in the external IncrementalExecutor that has been set. If it doesn't exist in the external IncrementalExecutor either, it goes to HandleMissingFunction.

Interpreter constructor overloading 
-------------------------------------------------
The overloading constructor of the Interpreter takes as argument the pointer to the master Interpreter. This is used for the initialization of the IncrementalParser  and to avoid the set up or the runtime environment in the constructor. This is done to reduce the memory consumption during the creation and set up of the second Interpreter. 

IncrementalParser.cpp, IncrementalParser.h
-------------------------------------------------------------
The function Initialize() of the IncrementalParser takes a bool argument to know whether it is called from a “master” Interpreter or from a “slave” Interpreter.
If it is a slave Interpreter, it avoids to include <new>, and in turn it reduces the memory consumption for the creation of the second Interpreter. 

Small change in /clang/lib/Sema/SemaOpenMP.cpp
-----------------------------------------------------------------------
This small change has been done in order to improve the memory consumption of the multiple interpreters. 
