### PR TITLE
First commit for the Multiple Interpreters

### DIFF
--- a/interpreter/cling/lib/Interpreter/ASTImportSource.cpp
+++ b/interpreter/cling/lib/Interpreter/ASTImportSource.cpp
@@ -5,167 +5,192 @@ using namespace clang;
 
 namespace cling {
 
-    ASTImportSource::ASTImportSource(cling::Interpreter *parent_interpreter,
-    cling::Interpreter *child_interpreter) :
+  ASTImportSource::ASTImportSource(cling::Interpreter *parent_interpreter,
+                                   cling::Interpreter *child_interpreter) :
     m_parent_Interp(parent_interpreter), m_child_Interp(child_interpreter) {
 
-      clang::DeclContext *parentTUDeclContext =
-        clang::TranslationUnitDecl::castToDeclContext(
-          m_parent_Interp->getCI()->getASTContext().getTranslationUnitDecl());
+    clang::DeclContext *parentTUDeclContext =
+      clang::TranslationUnitDecl::castToDeclContext(
+        m_parent_Interp->getCI()->getASTContext().getTranslationUnitDecl());
 
-      clang::DeclContext *childTUDeclContext =
-        clang::TranslationUnitDecl::castToDeclContext(
-          m_child_Interp->getCI()->getASTContext().getTranslationUnitDecl());
+    clang::DeclContext *childTUDeclContext =
+      clang::TranslationUnitDecl::castToDeclContext(
+        m_child_Interp->getCI()->getASTContext().getTranslationUnitDecl());
 
-      // Also keep in the map of Decl Contexts the Translation Unit Decl Context
-      m_DeclContexts_map[childTUDeclContext] = parentTUDeclContext;
+    // Also keep in the map of Decl Contexts the Translation Unit Decl Context
+    m_DeclContexts_map[childTUDeclContext] = parentTUDeclContext;
+  }
+
+  void ASTImportSource::ImportDecl(Decl *declToImport,
+                                   ASTImporter &importer,
+                                   DeclarationName &childDeclName,
+                                   DeclarationName &parentDeclName,
+                                   const DeclContext *childCurrentDeclContext) {
+
+    // Don't do the import if we have a Function Template.
+    // Not supported by clang.
+    // FIXME: This is also a temporary check. Will be de-activated
+    // once clang supports the import of function templates.
+    if (declToImport->isFunctionOrFunctionTemplate()
+        && declToImport->isTemplateDecl())
+      return;
+
+    if (Decl *importedDecl = importer.Import(declToImport)) {
+      if (NamedDecl *importedNamedDecl
+            = llvm::dyn_cast<NamedDecl>(importedDecl)) {
+        std::vector < NamedDecl * > declVector{importedNamedDecl};
+        llvm::ArrayRef < NamedDecl * > FoundDecls(declVector);
+        SetExternalVisibleDeclsForName(childCurrentDeclContext,
+                                       importedNamedDecl->getDeclName(),
+                                       FoundDecls);
+      }
+      // Put the name of the Decl imported with the
+      // DeclarationName coming from the parent, in  my map.
+      m_DeclName_map[childDeclName] = parentDeclName;
     }
+  }
 
-    void ASTImportSource::ImportDecl(Decl *declToImport,
-                                     ASTImporter &importer,
-                                     DeclarationName &childDeclName,
-                                     DeclarationName &parentDeclName,
-                                     const DeclContext *childCurrentDeclContext) {
+  void ASTImportSource::ImportDeclContext(DeclContext *declContextToImport,
+                                          ASTImporter &importer,
+                                          DeclarationName &childDeclName,
+                                          DeclarationName &parentDeclName,
+                                  const DeclContext *childCurrentDeclContext) {
 
-      // Don't do the import if we have a Function Template.
-      // Not supported by clang.
-      // FIXME: This is also a temporary check. Will be de-activated
-      // once clang supports the import of function templates.
-      if (declToImport->isFunctionOrFunctionTemplate() && declToImport->isTemplateDecl())
+    // If this DeclContext is a namespace, import only its "original" declaration.
+    if (NamespaceDecl *namespaceDecl
+         = llvm::dyn_cast<NamespaceDecl>(declContextToImport)) {
+
+      if (!namespaceDecl->isOriginalNamespace()) {
+
+        NamespaceDecl *originalNamespace
+          = namespaceDecl->getOriginalNamespace();
+        DeclContext *originalDeclContext
+          = llvm::dyn_cast<DeclContext>(originalNamespace);
+
+        if (m_DeclContexts_map.find(originalDeclContext)
+              == m_DeclContexts_map.end()) {
+          ImportDeclContext(originalDeclContext, importer, childDeclName,
+                            parentDeclName,
+                            childCurrentDeclContext);
+        }
         return;
-
-      if (Decl *importedDecl = importer.Import(declToImport)) {
-        if (NamedDecl *importedNamedDecl = llvm::dyn_cast<NamedDecl>(importedDecl)) {
-          std::vector < NamedDecl * > declVector{importedNamedDecl};
-          llvm::ArrayRef < NamedDecl * > FoundDecls(declVector);
-          SetExternalVisibleDeclsForName(childCurrentDeclContext,
-                                         importedNamedDecl->getDeclName(),
-                                         FoundDecls);
-        }
-        // Put the name of the Decl imported with the
-        // DeclarationName coming from the parent, in  my map.
-        m_DeclName_map[childDeclName] = parentDeclName;
       }
     }
+    if (DeclContext *importedDeclContext
+         = importer.ImportContext(declContextToImport)) {
 
-    void ASTImportSource::ImportDeclContext(DeclContext *declContextToImport,
-                                            ASTImporter &importer,
-                                            DeclarationName &childDeclName,
-                                            DeclarationName &parentDeclName,
-                                            const DeclContext *childCurrentDeclContext) {
+      importedDeclContext->setHasExternalVisibleStorage(true);
 
-      if (DeclContext *importedDeclContext = importer.ImportContext(declContextToImport)) {
+      if (NamedDecl *importedNamedDecl
+           = llvm::dyn_cast<NamedDecl>(importedDeclContext)) {
+        std::vector < NamedDecl * > declVector{importedNamedDecl};
+        llvm::ArrayRef < NamedDecl * > FoundDecls(declVector);
+        SetExternalVisibleDeclsForName(childCurrentDeclContext,
+                                       importedNamedDecl->getDeclName(),
+                                       FoundDecls);
+      }
+      // Put the name of the DeclContext imported with the
+      // DeclarationName coming from the parent, in  my map.
+      m_DeclName_map[childDeclName] = parentDeclName;
 
-        importedDeclContext->setHasExternalVisibleStorage(true);
+      // And also put the declaration context I found from the parent Interpreter
+      // in the map of the child Interpreter to have it for the future.
+      m_DeclContexts_map[importedDeclContext] = declContextToImport;
+    }
+  }
 
-        if (NamedDecl *importedNamedDecl = llvm::dyn_cast<NamedDecl>(importedDeclContext)) {
-          std::vector < NamedDecl * > declVector{importedNamedDecl};
-          llvm::ArrayRef < NamedDecl * > FoundDecls(declVector);
-          SetExternalVisibleDeclsForName(childCurrentDeclContext,
-                                         importedNamedDecl->getDeclName(),
-                                         FoundDecls);
-        }
-        // Put the name of the DeclContext imported with the
-        // DeclarationName coming from the parent, in  my map.
-        m_DeclName_map[childDeclName] = parentDeclName;
+  bool ASTImportSource::Import(DeclContext::lookup_result lookup_result,
+                               ASTContext &from_ASTContext,
+                               ASTContext &to_ASTContext,
+                               const DeclContext *childCurrentDeclContext,
+                               DeclarationName &childDeclName,
+                               DeclarationName &parentDeclName) {
 
-        // And also put the declaration context I found from the parent Interpreter
-        // in the map of the child Interpreter to have it for the future.
-        m_DeclContexts_map[importedDeclContext] = declContextToImport;
+    // Prepare to import the Decl(Context)  we found in the
+    // child interpreter by getting the file managers from
+    // each interpreter.
+    FileManager &child_FM = m_child_Interp->getCI()->getFileManager();
+    FileManager &parent_FM = m_parent_Interp->getCI()->getFileManager();
+
+    // Clang's ASTImporter
+    ASTImporter importer(to_ASTContext, child_FM,
+                         from_ASTContext, parent_FM,
+                         /*MinimalImport : ON*/ true);
+
+    for (DeclContext::lookup_iterator I = lookup_result.begin(),
+         E = lookup_result.end();
+         I != E; ++I) {
+      // Check if this Name we are looking for is
+      // a DeclContext (for example a Namespace, function etc.).
+      if (DeclContext *declContextToImport = llvm::dyn_cast<DeclContext>(*I)) {
+
+        ImportDeclContext(declContextToImport, importer, childDeclName,
+                          parentDeclName, childCurrentDeclContext);
+
+      } else if (Decl *declToImport = llvm::dyn_cast<Decl>(*I)) {
+
+        // else it is a Decl
+        ImportDecl(declToImport, importer, childDeclName,
+                   parentDeclName, childCurrentDeclContext);
       }
     }
+    return true;
+  }
 
-    bool ASTImportSource::Import(DeclContext::lookup_result lookup_result,
-                                 ASTContext &from_ASTContext,
-                                 ASTContext &to_ASTContext,
-                                 const DeclContext *childCurrentDeclContext,
-                                 DeclarationName &childDeclName,
-                                 DeclarationName &parentDeclName) {
+  ///\brief This is the most important function of the class ASTImportSource
+  /// since from here initiates the lookup and import part of the missing
+  /// Decl(s) (Contexts).
+  ///
+  bool ASTImportSource::FindExternalVisibleDeclsByName(
+    const DeclContext *childCurrentDeclContext, DeclarationName childDeclName) {
 
-      // Prepare to import the Decl(Context)  we found in the
-      // child interpreter by getting the file managers from
-      // each interpreter.
-      FileManager &child_FM = m_child_Interp->getCI()->getFileManager();
-      FileManager &parent_FM = m_parent_Interp->getCI()->getFileManager();
+    assert(childCurrentDeclContext->hasExternalVisibleStorage() &&
+           "DeclContext has no visible decls in storage");
 
-      // Clang's ASTImporter
-      ASTImporter importer(to_ASTContext, child_FM,
-                           from_ASTContext, parent_FM,
-                           /*MinimalImport : ON*/ true);
+    //Check if we have already found this declaration Name before
+    DeclarationName parentDeclName;
+    std::map<clang::DeclarationName, clang::DeclarationName>::iterator II
+      = m_DeclName_map.find(childDeclName);
 
-      for (DeclContext::lookup_iterator I = lookup_result.begin(),
-             E = lookup_result.end();
-             I != E; ++I) {
-        // Check if this Name we are looking for is
-        // a DeclContext (for example a Namespace, function etc.).
-        if (DeclContext *declContextToImport = llvm::dyn_cast<DeclContext>(*I)) {
-
-          ImportDeclContext(declContextToImport, importer, childDeclName,
-                            parentDeclName, childCurrentDeclContext);
-
-        } else if (Decl *declToImport = llvm::dyn_cast<Decl>(*I)) {
-
-          // else it is a Decl
-          ImportDecl(declToImport, importer, childDeclName,
-                     parentDeclName, childCurrentDeclContext);
-        }
-      }
-      return true;
+    if (II != m_DeclName_map.end()) {
+      parentDeclName = II->second;
+    } else {
+      // Get the identifier info from the parent interpreter
+      // for this Name.
+      llvm::StringRef name(childDeclName.getAsString());
+      IdentifierTable &parentIdentifierTable =
+        m_parent_Interp->getCI()->getASTContext().Idents;
+      IdentifierInfo &parentIdentifierInfo = parentIdentifierTable.get(name);
+      DeclarationName parentDeclNameTemp(&parentIdentifierInfo);
+      parentDeclName = parentDeclNameTemp;
     }
 
-    ///\brief This is the most important function of the class ASTImportSource
-    /// since from here initiates the lookup and import part of the missing
-    /// Decl(s) (Contexts).
-    ///
-    bool ASTImportSource::FindExternalVisibleDeclsByName(
-      const DeclContext *childCurrentDeclContext, DeclarationName childDeclName) {
+    // Search in the map of the stored Decl Contexts for this
+    // Decl Context.
+    std::map<const clang::DeclContext *, clang::DeclContext *>::iterator I;
+    if ((I = m_DeclContexts_map.find(childCurrentDeclContext))
+        != m_DeclContexts_map.end()) {
+      // If childCurrentDeclContext was found before and is already in the map,
+      // then do the lookup using the stored pointer.
+      DeclContext *parentDeclContext = I->second;
 
-      assert(childCurrentDeclContext->hasExternalVisibleStorage() &&
-             "DeclContext has no visible decls in storage");
+      Decl *fromDeclContext = Decl::castFromDeclContext(parentDeclContext);
+      ASTContext &from_ASTContext = fromDeclContext->getASTContext();
 
-      //Check if we have already found this declaration Name before
-      DeclarationName parentDeclName;
-      std::map<clang::DeclarationName,
-        clang::DeclarationName>::iterator II = m_DeclName_map.find(childDeclName);
-      if (II != m_DeclName_map.end()) {
-        parentDeclName = II->second;
-      } else {
-        // Get the identifier info from the parent interpreter
-        // for this Name.
-        llvm::StringRef name(childDeclName.getAsString());
-        IdentifierTable &parentIdentifierTable =
-          m_parent_Interp->getCI()->getASTContext().Idents;
-        IdentifierInfo &parentIdentifierInfo = parentIdentifierTable.get(name);
-        DeclarationName parentDeclNameTemp(&parentIdentifierInfo);
-        parentDeclName = parentDeclNameTemp;
+      Decl *toDeclContext = Decl::castFromDeclContext(childCurrentDeclContext);
+      ASTContext &to_ASTContext = toDeclContext->getASTContext();
+
+      DeclContext::lookup_result lookup_result
+        = parentDeclContext->lookup(parentDeclName);
+
+      // Check if we found this Name in the parent interpreter
+      if (!lookup_result.empty()) {
+        // Do the import
+        if (Import(lookup_result, from_ASTContext, to_ASTContext,
+                   childCurrentDeclContext, childDeclName, parentDeclName))
+          return true;
       }
-
-      // Search in the map of the stored Decl Contexts for this
-      // Decl Context.
-      std::map<const clang::DeclContext *, clang::DeclContext *>::iterator I;
-      if ((I = m_DeclContexts_map.find(childCurrentDeclContext))
-           != m_DeclContexts_map.end()) {
-        // If childCurrentDeclContext was found before and is already in the map,
-        // then do the lookup using the stored pointer.
-        DeclContext *parentDeclContext = I->second;
-
-        Decl *fromDeclContext = Decl::castFromDeclContext(parentDeclContext);
-        ASTContext &from_ASTContext = fromDeclContext->getASTContext();
-
-        Decl *toDeclContext = Decl::castFromDeclContext(childCurrentDeclContext);
-        ASTContext &to_ASTContext = toDeclContext->getASTContext();
-
-        DeclContext::lookup_result lookup_result =
-          parentDeclContext->lookup(parentDeclName);
-
-        // Check if we found this Name in the parent interpreter
-        if (!lookup_result.empty()) {
-          // Do the import
-          if (Import(lookup_result, from_ASTContext, to_ASTContext,
-                     childCurrentDeclContext, childDeclName, parentDeclName))
-            return true;
-        }
-      }
-      return false;
     }
+    return false;
+  }
 } // end namespace cling

--- a/interpreter/cling/test/MultipleInterpreters/MultipleInterpreters.C
+++ b/interpreter/cling/test/MultipleInterpreters/MultipleInterpreters.C
@@ -35,4 +35,25 @@ ChildInterp.execute("foo()");
 //Check if function overloading works
 ChildInterp.execute("foo(1)");
 //CHECK:foo(int) = 1
+
+//Check for namespaces
+.rawInput 1
+namespace A { int x = 123; }
+namespace A { int y = 456; }
+.rawInput 0
+
+ChildInterp.declare("namespace A { int c = 22; }");
+ChildInterp.declare("namespace A { int d = 99; }");
+
+ChildInterp.execute("printf(\"%d\", A::x);");
+//CHECK:123
+
+ChildInterp.execute("printf(\"%d\", A::y);");
+//CHECK:456
+
+ChildInterp.execute("printf(\"%d\", A::c);");
+//CHECK:22
+
+ChildInterp.execute("printf(\"%d\", A::d);");
+//CHECK:99
 .q


### PR DESCRIPTION
First commit for the Multiple Interpreters.
## ASTImportSource.cpp, ASTImportSource.h

The class that implements the importing functionalities for the multiple Interpreters.
It derives from the clang class ExternalASTSource, and overrides the function  FindExternalVisibleDeclsByname which does the search and importing of the ASTNodes by  calling the clang::ASTImporter.
This class must be created when setting up the second Interpreter and “passed” to its Translation Unit with the function setExternalSource.
## Symbol Resolution from the execution engine of the second interpreter.

In order for the second Interpreter to find and execute the correct functions that are defined in the first Interpreter, but are called from the second, the following changes have been made in the classes of IncrementalExecutor and Interpreter.

(IncrementalExecutor.cpp, IncrementalExecutor.h, Interpreter.cpp, Interpreter.h)

-Added a pointer to an 'external' IncrementalExecutor in IncrementalExecutor class, and a corresponding function to set the pointer ( IncrementalExecutor::setExternalIncrementalExecutor).

```
-Added in Interpreter a getIncrementalExecutor() function to get a pointer to its IncrementalExecutor.

-Added in Interpreter a function Interpreter::setExternalIncrementalExecutor which calls IncrementalExecutor's setExternalIncrementalExecutor function.

-Edited IncrementalExecutor::NotifyLazyFunctionCreators to search for the address of a missing symbol in the external IncrementalExecutor that has been set. If it doesn't exist in the external IncrementalExecutor either, it goes to HandleMissingFunction.
```
## Interpreter constructor overloading 

The overloading constructor of the Interpreter takes as argument the pointer to the parent Interpreter. This is used for the initialization of the IncrementalParser  and to avoid the set up or the runtime environment in the constructor. This is done to reduce the memory consumption during the creation and set up of the second Interpreter. 
## IncrementalParser.cpp, IncrementalParser.h

The function Initialize() of the IncrementalParser takes a bool argument to know whether it is called from a “parent” Interpreter or from a "child” Interpreter.
If it is a child Interpreter, it avoids to include <new>, and in turn it reduces the memory consumption for the creation of the second Interpreter. 
