### PR TITLE
Visit Stmt children for null deref check.

### DIFF
--- a/interpreter/cling/lib/Interpreter/NullDerefProtectionTransformer.cpp
+++ b/interpreter/cling/lib/Interpreter/NullDerefProtectionTransformer.cpp
@@ -10,12 +10,10 @@
 
 #include "NullDerefProtectionTransformer.h"
 
-#include "cling/Interpreter/Transaction.h"
 #include "cling/Utils/AST.h"
 
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/Decl.h"
-#include "clang/AST/Mangle.h"
 #include "clang/AST/StmtVisitor.h"
 #include "clang/Basic/SourceLocation.h"
 #include "clang/Sema/Lookup.h"
@@ -33,7 +31,7 @@ namespace cling {
   NullDerefProtectionTransformer::~NullDerefProtectionTransformer()
   { }
 
-  class IfStmtInjector : public StmtVisitor<IfStmtInjector, void> {
+  class PointerCheckInjector : public StmtVisitor<PointerCheckInjector, void> {
   private:
     Sema& m_Sema;
     typedef std::map<clang::FunctionDecl*, std::bitset<32> > decl_map_t;
@@ -48,11 +46,8 @@ namespace cling {
     LookupResult* m_LookupResult;
 
   public:
-    IfStmtInjector(Sema& S) : m_Sema(S), m_Context(S.getASTContext()),
+    PointerCheckInjector(Sema& S) : m_Sema(S), m_Context(S.getASTContext()),
     m_LookupResult(0) {}
-    void Inject(CompoundStmt* CS) {
-      VisitStmt(CS);
-    }
 
     void VisitStmt(Stmt* S) {
       for (auto child: S->children()) {
@@ -64,17 +59,14 @@ namespace cling {
     void VisitUnaryOperator(UnaryOperator* UnOp) {
       Visit(UnOp->getSubExpr());
       if (UnOp->getOpcode() == UO_Deref) {
-        Expr* newSubExpr = SynthesizeCheck(UnOp->getLocStart(),
-                                 UnOp->getSubExpr());
-        UnOp->setSubExpr(newSubExpr);
+        UnOp->setSubExpr(SynthesizeCheck(UnOp->getSubExpr()));
       }
     }
 
     void VisitMemberExpr(MemberExpr* ME) {
       Visit(ME->getBase());
       if (ME->isArrow()) {
-        Expr* newBase = SynthesizeCheck(ME->getLocStart(), ME->getBase());
-        ME->setBase(newBase);
+        ME->setBase(SynthesizeCheck(ME->getBase()));
       }
     }
 
@@ -89,24 +81,24 @@ namespace cling {
           if (ArgIndexs.test(index)) {
             // Get the argument with the nonnull attribute.
             Expr* Arg = CE->getArg(index);
-            Expr* newArg = SynthesizeCheck(Arg->getLocStart(), Arg);
-            CE->setArg(index, newArg);
+            CE->setArg(index, SynthesizeCheck(Arg));
           }
         }
       }
     }
 
   private:
-    Expr* SynthesizeCheck(SourceLocation Loc, Expr* Arg) {
+    Expr* SynthesizeCheck(Expr* Arg) {
       assert(Arg && "Cannot call with Arg=0");
 
       if(!m_LookupResult)
         FindAndCacheRuntimeLookupResult();
 
+      SourceLocation Loc = Arg->getLocStart();
+
       Expr* VoidSemaArg = utils::Synthesize::CStyleCastPtrExpr(&m_Sema,
                                                             m_Context.VoidPtrTy,
                                                             (uint64_t)&m_Sema);
-
       Expr* VoidExprArg = utils::Synthesize::CStyleCastPtrExpr(&m_Sema,
                                                           m_Context.VoidPtrTy,
                                                           (uint64_t)Arg);
@@ -114,15 +106,12 @@ namespace cling {
       Expr *args[] = {VoidSemaArg, VoidExprArg, Arg};
 
       Scope* S = m_Sema.getScopeForContext(m_Sema.CurContext);
-
       CXXScopeSpec CSS;
       Expr* unresolvedLookup
         = m_Sema.BuildDeclarationNameExpr(CSS, *m_LookupResult,
                                          /*ADL*/ false).get();
-
       Expr* call = m_Sema.ActOnCallExpr(S, unresolvedLookup, Loc,
                                         args, Loc).get();
-
       TypeSourceInfo* TSI
               = m_Context.getTrivialTypeSourceInfo(Arg->getType(), Loc);
       Expr* castExpr = m_Sema.BuildCStyleCastExpr(Loc, TSI, Loc, call).get();
@@ -132,6 +121,9 @@ namespace cling {
 
     bool isDeclCandidate(FunctionDecl * FDecl) {
       if (m_NonNullArgIndexs.count(FDecl))
+        return true;
+
+      if (llvm::isa<CXXRecordDecl>(FDecl))
         return true;
 
       std::bitset<32> ArgIndexs;
@@ -158,7 +150,6 @@ namespace cling {
 
       DeclarationName Name
         = &m_Context.Idents.get("cling_runtime_internal_throwIfInvalidPointer");
-
       SourceLocation noLoc;
       m_LookupResult = new LookupResult(m_Sema, Name, noLoc,
                                         Sema::LookupOrdinaryName,
@@ -180,9 +171,9 @@ namespace cling {
     if (!CS)
       return Result(D, true);
 
-    IfStmtInjector injector(*m_Sema);
-    injector.Inject(CS);
-    FD->setBody(CS);
+    PointerCheckInjector injector(*m_Sema);
+    injector.Visit(CS);
+
     return Result(FD, true);
   }
 } // end namespace cling


### PR DESCRIPTION
The previous version of the Null deref visitor was defaulting to
VisitStmt when the Stmt type was unknown, thus allowing for some
types of Stmt X for which a VisitX was not implemented to default
to VisitStmt and not check the content of it. In order to check
any type of Stmt for possible subexpressions which contain s Stmt
that derefrences a Null, the VisitStmt was extended to check its
children.

Only the Stmt types, X, which directly containing a null deref expression
have an explicit VisitX with the exception of CXXMemberCallExpr,
because this type would otherwise default to VisitCallExpr which has
a different check for its structure.