### PR TITLE
Add tests for cling NullDeref.

### DIFF
--- a/interpreter/cling/test/NullDeref/ExecutionTermination.C
+++ b/interpreter/cling/test/NullDeref/ExecutionTermination.C
@@ -1,0 +1,18 @@
+//------------------------------------------------------------------------------
+// CLING - the C++ LLVM-based InterpreterG :)
+//
+// This file is dual-licensed: you can choose to license it under the University
+// of Illinois Open Source License or the GNU Lesser General Public License. See
+// LICENSE.TXT for details.
+//------------------------------------------------------------------------------
+
+// RUN: cat %s | %cling -Xclang -verify
+//This file checks that the execution ends after a null prt dereference.
+
+#include <stdlib.h>
+
+int *p = (int*)0x1;
+*p; exit(1); // expected-warning {{invalid memory pointer passed to a callee:}}
+
+.q
+

--- a/interpreter/cling/test/NullDeref/If.C
+++ b/interpreter/cling/test/NullDeref/If.C
@@ -1,0 +1,22 @@
+//------------------------------------------------------------------------------
+// CLING - the C++ LLVM-based InterpreterG :)
+//
+// This file is dual-licensed: you can choose to license it under the University
+// of Illinois Open Source License or the GNU Lesser General Public License. See
+// LICENSE.TXT for details.
+//------------------------------------------------------------------------------
+
+// RUN: cat %s | %cling -Xclang -verify
+//This file checks an if statement for null prt dereference.
+
+#include <stdlib.h>
+
+int* p = 0;
+
+if (*p) { exit(1); } // expected-warning {{null passed to a callee that requires a non-null argument}}
+
+if (true) { *p; exit(1); } // expected-warning {{null passed to a callee that requires a non-null argument}}
+
+if (false) {} else { *p; exit(1); } // expected-warning {{null passed to a callee that requires a non-null argument}}
+
+.q


### PR DESCRIPTION
If stmt testing and checking that the execution is stopped after
a null deref warning.