### PR TITLE
Ctrl-C clears input

### DIFF
--- a/core/rint/src/TRint.cxx
+++ b/core/rint/src/TRint.cxx
@@ -98,14 +98,17 @@ Bool_t TInterruptHandler::Notify()
    // make sure we use the sbrk heap (in case of mapped files)
    gMmallocDesc = 0;
 
-   Break("TInterruptHandler::Notify", "keyboard interrupt");
-   if (TROOT::Initialized()) {
+   if (TROOT::Initialized() && gROOT->IsLineProcessing()) {
+      Break("TInterruptHandler::Notify", "keyboard interrupt");
       Getlinem(kInit, "Root > ");
       gCling->Reset();
 #ifndef WIN32
    if (gException)
       Throw(GetSignal());
 #endif
+   } else {
+      // Reset input.
+      Getlinem(kClear, ((TRint*)gApplication)->GetPrompt());
    }
 
    return kTRUE;

--- a/core/textinput/inc/Getline.h
+++ b/core/textinput/inc/Getline.h
@@ -22,7 +22,7 @@ extern "C" {
 #endif
 #endif
 
-typedef enum { kInit = -1, kLine1, kOneChar, kCleanUp } EGetLineMode;
+typedef enum { kInit = -1, kLine1, kOneChar, kCleanUp, kClear } EGetLineMode;
 
 const char *Getline(const char *prompt);
 const char *Getlinem(EGetLineMode mode, const char *prompt);

--- a/core/textinput/src/Getline.cxx
+++ b/core/textinput/src/Getline.cxx
@@ -107,8 +107,8 @@ namespace {
          delete fDisplay;
       }
 
-      const char* TakeInput() {
-         fTextInput.TakeInput(fInputLine);
+      const char* TakeInput(bool force = false) {
+         fTextInput.TakeInput(fInputLine, force);
          fInputLine += "\n"; // ROOT wants a trailing newline.
          return fInputLine.c_str();
       }
@@ -183,10 +183,15 @@ Gl_histadd(const char* buf) {
 }
 
 /* Wrapper around textinput.
- * Modes: -1 = init, 0 = line mode, 1 = one char at a time mode, 2 = cleanup
+ * Modes: -1 = init, 0 = line mode, 1 = one char at a time mode, 2 = cleanup, 3 = clear input line
  */
 const char*
 Getlinem(EGetLineMode mode, const char* prompt) {
+
+   if (mode == kClear) {
+      TextInputHolder::getHolder().TakeInput(true);
+      return 0;
+   }
 
    if (mode == kCleanUp) {
       TextInputHolder::get().ReleaseInputOutput();

--- a/core/textinput/src/textinput/TextInput.cpp
+++ b/core/textinput/src/textinput/TextInput.cpp
@@ -49,8 +49,8 @@ namespace textinput {
   }
 
   void
-  TextInput::TakeInput(std::string &input) {
-    if (fLastReadResult != kRRReadEOLDelimiter
+  TextInput::TakeInput(std::string &input, bool force) {
+    if (!force && fLastReadResult != kRRReadEOLDelimiter
         && fLastReadResult != kRREOF) {
       input.clear();
       return;
@@ -67,12 +67,14 @@ namespace textinput {
 
     ReleaseInputOutput();
 
-    if (fLastReadResult == kRRReadEOLDelimiter) {
+    if (force || fLastReadResult == kRRReadEOLDelimiter) {
       // Input has been taken, we can continue reading.
       fLastReadResult = kRRNone;
       // We will have to redraw the prompt, even if unchanged.
       fNeedPromptRedraw = true;
-    } // else keep EOF.
+    } else {
+      fLastReadResult = kRREOF;
+    }
   }
 
   bool

--- a/core/textinput/src/textinput/TextInput.h
+++ b/core/textinput/src/textinput/TextInput.h
@@ -69,7 +69,7 @@ namespace textinput {
     EReadResult GetReadState() const { return fLastReadResult; }
     char GetLastKey() const { return fLastKey; }
     const std::string& GetInput();
-    void TakeInput(std::string& input); // Take and reset input
+    void TakeInput(std::string& input, bool force = false); // Take and reset input
     bool AtEOL() const { return fLastReadResult == kRRReadEOLDelimiter || AtEOF(); }
     bool AtEOF() const { return fLastReadResult == kRREOF; }
     bool HavePendingInput() const;


### PR DESCRIPTION
Let ^C clear input instead of interrupting nothing.