### PR TITLE
Null deref stack trace

### DIFF
--- a/interpreter/cling/lib/Interpreter/ExceptionRTTI.cpp
+++ b/interpreter/cling/lib/Interpreter/ExceptionRTTI.cpp
@@ -25,22 +25,26 @@ extern "C" {
 void* cling_runtime_internal_throwIfInvalidPointer(void* Interp, void* Expr,
                                                   const void* Arg) {
 
-  cling::Interpreter* I = (cling::Interpreter*)Interp;
   clang::Expr* E = (clang::Expr*)Expr;
-
-  // Print a nice backtrace.
-  I->getCallbacks()->PrintStackTrace();
 
   // The isValidAddress function return true even when the pointer is
   // null thus the checks have to be done before returning successfully from the
   // function in this specific order.
-  clang::Sema& S = I->getCI()->getSema();
-  if (!Arg)
+  if (!Arg) {
+    cling::Interpreter* I = (cling::Interpreter*)Interp;
+    clang::Sema& S = I->getCI()->getSema();
+    // Print a nice backtrace.
+    I->getCallbacks()->PrintStackTrace();
     throw cling::InvalidDerefException(&S, E,
           cling::InvalidDerefException::DerefType::NULL_DEREF);
-  else if (!cling::utils::isAddressValid(Arg))
+  } else if (!cling::utils::isAddressValid(Arg)) {
+    cling::Interpreter* I = (cling::Interpreter*)Interp;
+    clang::Sema& S = I->getCI()->getSema();
+    // Print a nice backtrace.
+    I->getCallbacks()->PrintStackTrace();
     throw cling::InvalidDerefException(&S, E,
           cling::InvalidDerefException::DerefType::INVALID_MEM);
+  }
   return const_cast<void*>(Arg);
 }
 }

--- a/interpreter/cling/lib/Interpreter/MultiplexInterpreterCallbacks.h
+++ b/interpreter/cling/lib/Interpreter/MultiplexInterpreterCallbacks.h
@@ -118,6 +118,11 @@ namespace cling {
       for (auto&& cb : m_Callbacks)
         cb->SetIsRuntime(val);
     }
+
+    void PrintStackTrace() override {
+      for (auto&& cb : m_Callbacks)
+        cb->PrintStackTrace();
+    }
   };
 } // end namespace cling
 


### PR DESCRIPTION
This fixes the observed crashes and really triggers stacktrace generation!
However, the produced stacktrace is not complete...
For more details, see my comment at https://sft.its.cern.ch/jira/browse/ROOT-8111 . 