### PR TITLE
Create option for disabling the Pointer check in cling::Interpreter::…

### DIFF
--- a/interpreter/cling/include/cling/Interpreter/CompilationOptions.h
+++ b/interpreter/cling/include/cling/Interpreter/CompilationOptions.h
@@ -58,6 +58,10 @@ namespace cling {
     /// is wrapped.
     unsigned IgnorePromptDiags : 1;
 
+    ///\brief Pointer validity check can be enabled/disabled.
+    ///
+    unsigned CheckPointerValidity : 1;
+
     CompilationOptions() {
       DeclarationExtraction = 0;
       ValuePrinting = VPDisabled;
@@ -67,6 +71,7 @@ namespace cling {
       CodeGeneration = 1;
       CodeGenerationForModule = 0;
       IgnorePromptDiags = 0;
+      CheckPointerValidity = 1;
     }
 
     bool operator==(CompilationOptions Other) const {
@@ -78,7 +83,8 @@ namespace cling {
         Debug                 == Other.Debug &&
         CodeGeneration        == Other.CodeGeneration &&
         CodeGenerationForModule == Other.CodeGenerationForModule &&
-        IgnorePromptDiags     == Other.IgnorePromptDiags;
+        IgnorePromptDiags     == Other.IgnorePromptDiags &&
+        CheckPointerValidity  == Other.CheckPointerValidity;
     }
 
     bool operator!=(CompilationOptions Other) const {
@@ -90,7 +96,8 @@ namespace cling {
         Debug                 != Other.Debug ||
         CodeGeneration        != Other.CodeGeneration ||
         CodeGenerationForModule != Other.CodeGenerationForModule ||
-        IgnorePromptDiags     != Other.IgnorePromptDiags;
+        IgnorePromptDiags     != Other.IgnorePromptDiags ||
+        CheckPointerValidity  != Other.CheckPointerValidity;
     }
   };
 } // end namespace cling

--- a/interpreter/cling/lib/Interpreter/ASTTransformer.h
+++ b/interpreter/cling/lib/Interpreter/ASTTransformer.h
@@ -94,7 +94,9 @@ namespace cling {
     ///
     Result Transform(clang::Decl* D, Transaction* T) {
       m_Transaction = T;
-      return Transform(D);
+      if (getCompilationOpts().CheckPointerValidity)
+        return Transform(D);
+      return Result(D, true);
     }
 
   protected:

--- a/interpreter/cling/lib/Interpreter/Interpreter.cpp
+++ b/interpreter/cling/lib/Interpreter/Interpreter.cpp
@@ -633,6 +633,7 @@ namespace cling {
     CO.ResultEvaluation = 0;
     CO.DynamicScoping = isDynamicLookupEnabled();
     CO.Debug = isPrintingDebug();
+    CO.CheckPointerValidity = 0;
 
     return DeclareInternal(input, CO, T);
   }


### PR DESCRIPTION
…declare.

To improve performance we limit the use of the Pointer validity check
and remove it from cling::Interpreter::declare.
To do this we introduce a Compilation Option which is used by the
ASTTransformer through Transaction.