### PR TITLE
Register the result of TChain::Load with the TChainElement.

### DIFF
--- a/tree/tree/inc/TChainElement.h
+++ b/tree/tree/inc/TChainElement.h
@@ -45,6 +45,7 @@ protected:
    Bool_t        fBaddressIsPtr;     ///<! True if the address is a pointer to an address
    char         *fPackets;           ///<! Packet descriptor string
    TBranch     **fBranchPtr;         ///<! Address of user branch pointer (to updated upon loading a file)
+   Int_t         fLoadResult;        ///<! Return value of TChain::LoadTree(); 0 means success
 
 public:
    TChainElement();
@@ -57,6 +58,7 @@ public:
    virtual UInt_t      GetBaddressType() const { return fBaddressType; }
    virtual TBranch   **GetBranchPtr() const { return fBranchPtr; }
    virtual Long64_t    GetEntries() const {return fEntries;}
+           Int_t       GetLoadResult() const { return fLoadResult; }
    virtual char       *GetPackets() const {return fPackets;}
    virtual Int_t       GetPacketSize() const {return fPacketSize;}
    virtual Int_t       GetStatus() const {return fStatus;}
@@ -67,6 +69,7 @@ public:
    virtual void        SetBaddressIsPtr(Bool_t isptr) { fBaddressIsPtr = isptr; }
    virtual void        SetBaddressType(UInt_t type) { fBaddressType = type; }
    virtual void        SetBranchPtr(TBranch **ptr) { fBranchPtr = ptr; }
+           void        SetLoadResult(Int_t result) { fLoadResult = result; }
    virtual void        SetLookedUp(Bool_t y = kTRUE);
    virtual void        SetNumberEntries(Long64_t n) {fEntries=n;}
    virtual void        SetPacketSize(Int_t size = 100);

--- a/tree/tree/src/TChain.cxx
+++ b/tree/tree/src/TChain.cxx
@@ -1527,12 +1527,15 @@ Long64_t TChain::LoadTree(Long64_t entry)
                fNotify->Notify();
             }
 
-            return LoadTree(entry);
+            Long64_t loadResult = LoadTree(entry);
+            element->SetLoadResult(loadResult);
+            return loadResult;
          } else {
             treeReadEntry = fReadEntry = -2;
          }
       }
    }
+
 
    if (!fTree) {
       // The Error message already issued.  However if we reach here
@@ -1540,6 +1543,9 @@ Long64_t TChain::LoadTree(Long64_t entry)
       //
       // Force a reload of the tree next time.
       fTreeNumber = -1;
+
+      element->SetLoadResult(returnCode);
+
       return returnCode;
    }
    // ----- End of modifications by MvL
@@ -1559,7 +1565,8 @@ Long64_t TChain::LoadTree(Long64_t entry)
    // they use the correct read entry number).
 
    // Change the new current tree to the new entry.
-   fTree->LoadTree(treeReadEntry);
+   Long64_t loadResult = fTree->LoadTree(treeReadEntry);
+   element->SetLoadResult(loadResult);
 
    // Change the chain friends to the new entry.
    if (fFriends) {

--- a/tree/tree/src/TChainElement.cxx
+++ b/tree/tree/src/TChainElement.cxx
@@ -27,7 +27,7 @@ ClassImp(TChainElement)
 /// Default constructor for a chain element.
 
 TChainElement::TChainElement() : TNamed(),fBaddress(0),fBaddressType(0),
-                                 fBaddressIsPtr(kFALSE), fBranchPtr(0)
+   fBaddressIsPtr(kFALSE), fBranchPtr(0), fLoadResult(0)
 {
    fNPackets   = 0;
    fPackets    = 0;
@@ -42,7 +42,7 @@ TChainElement::TChainElement() : TNamed(),fBaddress(0),fBaddressType(0),
 
 TChainElement::TChainElement(const char *name, const char *title)
    :TNamed(name,title),fBaddress(0),fBaddressType(0),
-    fBaddressIsPtr(kFALSE), fBranchPtr(0)
+    fBaddressIsPtr(kFALSE), fBranchPtr(0), fLoadResult(0)
 {
    fNPackets   = 0;
    fPackets    = 0;


### PR DESCRIPTION
Fails with
  TChain ch("ntuple");
  ch.Add("tutorials/hsimple.root")
  ch.Add("tutorials/hsimpleNO.root")
  ch.Add("hsimple.root")
where the last one is a copy of tutorials/hsimple.root: when loading the second tree, Notify() is called, and afterwards the chain thinks the element is the last one, "skipping" tutorials/hsimpleNO.root.